### PR TITLE
remove QHostAddress and fix mac socket error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ set(QTNETWORKNG_SRC
     src/socks5_proxy.cpp
     src/msgpack.cpp
     src/data_channel.cpp
+    src/hostaddress.cpp
 
     src/socket_server.cpp
     src/httpd.cpp
@@ -82,6 +83,7 @@ set(QTNETWORKNG_INCLUDE
     include/msgpack.h
     include/data_channel.h
     include/kcp.h
+    include/hostaddress.h
 )
 
 SET(QTNETWORKNG_PRIVATE_INCLUDE

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To create IPv4 tcp server.
 
     Socket s;
     CoroutineGroup workers;
-    s.bind(QHostAddress::Any, 8000);
+    s.bind(HostAddress::Any, 8000);
     s.listen(100);
     while (true) {
         QSharedPointer<Socket> request(s.accept());
@@ -75,7 +75,7 @@ To create IPv4 tcp server.
 
 To create HTTP server is even more simpler:
 
-    TcpServer<SimpleHttpRequestHandler> httpd(QHostAddress::LocalHost, 8000);
+    TcpServer<SimpleHttpRequestHandler> httpd(HostAddress::LocalHost, 8000);
     httpd.serveForever();
 
 A Qt GUI example to fetch web page.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -60,7 +60,7 @@ To create IPv4 tcp server.
     
     Socket s;
     CoroutineGroup workers;
-    s.bind(QHostAddress::AnyIPv4, 8000);
+    s.bind(HostAddress::AnyIPv4, 8000);
     s.listen(100);
     while(true) {
         QSharedPointer<Socket> request(s.accept());

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -319,7 +319,7 @@ Combine ``Socket`` and ``Coroutine``, you can create socket server in few lines 
 .. code-block:: c++
     :caption: tcp server
     
-    QScopedPointer<Socket> s(Socket::createServer(QHostAddress::AnyIPv4, 8000, 100));
+    QScopedPointer<Socket> s(Socket::createServer(HostAddress::AnyIPv4, 8000, 100));
     CoroutineGroup operations;
     while(true) {
         QSharedPointer<Socket> request(s->accept());

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -845,7 +845,7 @@ Create socket is very simple, just instantiate ``Socket`` class. Or pass the pla
 .. code-block:: c++
     :caption: Socket constructor
     
-    Socket(NetworkLayerProtocol protocol = AnyIPProtocol, SocketType type = TcpSocket);
+    Socket(HostAddress::NetworkLayerProtocol protocol = AnyIPProtocol, SocketType type = TcpSocket);
     
     Socket(qintptr socketDescriptor);
     
@@ -861,7 +861,7 @@ These are the member functions of ``Socket`` type.
 
     If the socket is currently listening, ``accept()`` block current coroutine, and return new ``Socket`` object after new client connected. The returned new ``Socket`` object has connected to the new client. This function returns ``0`` to indicate the socket is closed by other coroutine.
 
-.. method:: bool bind(QHostAddress &address, quint16 port = 0, BindMode mode = DefaultForPlatform)
+.. method:: bool bind(HostAddress &address, quint16 port = 0, BindMode mode = DefaultForPlatform)
 
     Bind the socket to ``address`` and ``port``. If the parameter ``port`` is ommited, the Operating System choose an unused random port for you. The chosen port can obtained from ``port()`` function later. The parameter ``mode`` is not used now. 
     
@@ -871,13 +871,13 @@ These are the member functions of ``Socket`` type.
 
     Bind the socket to any address and ``port``. This function overloads ``bind(address, port)``.
 
-.. method:: bool connect(const QHostAddress &host, quint16 port)
+.. method:: bool connect(const HostAddress &host, quint16 port)
 
     Connect to remote host specified by parameters ``host`` and ``port``. Block current coroutine until the connection is established or failed.
     
     This function returns true if the connection is established.
 
-.. method:: bool connect(const QString &hostName, quint16 port, NetworkLayerProtocol protocol = AnyIPProtocol)
+.. method:: bool connect(const QString &hostName, quint16 port, HostAddress::NetworkLayerProtocol protocol = AnyIPProtocol)
 
     Connect to remote host specified by parameters ``hostName`` and ``port``, using ``protocol``. If ``hostName`` is not an IP address, QtNetworkNg will make a DNS query before connecting. Block current coroutine until the connection is established or failed.
     
@@ -977,7 +977,7 @@ These are the member functions of ``Socket`` type.
     
     If some error occured, this function returns `-1`. You can use ``error()`` and ``errorString()`` to get the error message.
 
-.. method:: qint32 recvfrom(char *data, qint32 size, QHostAddress *addr, quint16 *port)
+.. method:: qint32 recvfrom(char *data, qint32 size, HostAddress *addr, quint16 *port)
 
     Receive not more than ``size`` of data from connection. Blocks current coroutine until some data arrived.
     
@@ -987,7 +987,7 @@ These are the member functions of ``Socket`` type.
     
     If some error occured, function returns `-1`. You can use ``error()`` and ``errorString()`` to get the error message.
 
-.. method:: qint32 sendto(const char *data, qint32 size, const QHostAddress &addr, quint16 port)
+.. method:: qint32 sendto(const char *data, qint32 size, const HostAddress &addr, quint16 port)
 
     Send ``size`` of ``data`` to remote host specified by ``addr`` and ``port``. Block current coroutine until some data sent.
     
@@ -1039,7 +1039,7 @@ These are the member functions of ``Socket`` type.
     
     This function overloads ``sendall(char*, qint32)``.
 
-.. method:: QByteArray recvfrom(qint32 size, QHostAddress *addr, quint16 *port)
+.. method:: QByteArray recvfrom(qint32 size, HostAddress *addr, quint16 *port)
 
     Receive not more than ``size`` of data from connection. Blocks current coroutine until some data arrived.
     
@@ -1049,9 +1049,9 @@ These are the member functions of ``Socket`` type.
     
     This function can not indicate whether there is any error occured. If this function returns empty data, use ``error()`` to check error, and ``errorString()`` to get the error message.
     
-    This function overloads ``recvfrom(char*, qint32, QHostAddress*, quint16*)``.
+    This function overloads ``recvfrom(char*, qint32, HostAddress*, quint16*)``.
 
-.. method:: qint32 sendto(const QByteArray &data, const QHostAddress &addr, quint16 port)
+.. method:: qint32 sendto(const QByteArray &data, const HostAddress &addr, quint16 port)
 
     Send ``data`` to remote host specified by ``addr`` and ``port``. Block current coroutine until some data sent.
     
@@ -1075,19 +1075,19 @@ These are the member functions of ``Socket`` type.
 
     Return true if the socket is not closed.
     
-.. method:: QHostAddress localAddress() const
+.. method:: HostAddress localAddress() const
 
-    Return the host address of the local socket if available; otherwise returns ``QHostAddress::Null``.
+    Return the host address of the local socket if available; otherwise returns ``HostAddress::Null``.
     
-    This is normally the main IP address of the host, but can be ``QHostAddress::LocalHost`` (127.0.0.1) for connections to the local host.
+    This is normally the main IP address of the host, but can be ``HostAddress::LocalHost`` (127.0.0.1) for connections to the local host.
 
 .. method:: quint16 localPort() const
 
     Return the host port number (in native byte order) of the local socket if available; otherwise returns `0`.
     
-.. method:: QHostAddress peerAddress() const
+.. method:: HostAddress peerAddress() const
 
-    Return the address of the connected peer if the socket is in ``ConnectedState``; otherwise returns ``QHostAddress::Null``.
+    Return the address of the connected peer if the socket is in ``ConnectedState``; otherwise returns ``HostAddress::Null``.
     
 .. method:: QString peerName() const
 
@@ -1117,7 +1117,7 @@ These are the member functions of ``Socket`` type.
 
     Return the protocol of the socket.
 
-.. method:: static QList<QHostAddress> resolve(const QString &hostName)
+.. method:: static QList<HostAddress> resolve(const QString &hostName)
 
     Make a DNS query to resolve the ``hostName``. If the ``hostName`` is an IP address, return the IP immediately.
     
@@ -1135,7 +1135,7 @@ There are three constructors to create ``SslSocket``.
 .. code-block:: c++
     :caption: the constructors of SslSocket
     
-    SslSocket(Socket::NetworkLayerProtocol protocol = Socket::AnyIPProtocol, 
+    SslSocket(HostAddress::NetworkLayerProtocol protocol = Socket::AnyIPProtocol,
             const SslConfiguration &config = SslConfiguration());
     
     SslSocket(qintptr socketDescriptor, const SslConfiguration &config = SslConfiguration());
@@ -1275,7 +1275,7 @@ The second constructor use the ``hostName`` and ``port`` to create a valid Socks
     
     The DNS query of ``remoteHost`` is made at the proxy server.
     
-.. method:: QSharedPointer<Socket> connect(const QHostAddress &remoteHost, quint16 port)
+.. method:: QSharedPointer<Socket> connect(const HostAddress &remoteHost, quint16 port)
 
     Connect to ``remoteHost`` at ``port`` via this proxy.
     

--- a/examples/kcptun/client.cpp
+++ b/examples/kcptun/client.cpp
@@ -14,7 +14,7 @@ enum ParserResult
 struct Configure
 {
     QString password;
-    QHostAddress localAddress;
+    HostAddress localAddress;
     QString remoteAddress;
     quint16 localPort;
     quint16 remotePort;
@@ -124,7 +124,7 @@ ParserResult parseArguments(Configure *configure, QString *errorMessage)
 
     QString localAddressStr = parser.value(localAddressOption);
     if (localAddressStr.isEmpty()) {
-        configure->localAddress.setAddress(QHostAddress::LocalHost);
+        configure->localAddress.setAddress(HostAddress::LocalHost);
     } else {
         configure->localAddress.setAddress(localAddressStr);
         if (configure->localAddress.isNull()) {

--- a/examples/kcptun/server.cpp
+++ b/examples/kcptun/server.cpp
@@ -14,7 +14,7 @@ enum ParserResult
 struct Configure
 {
     QString password;
-    QHostAddress localAddress;
+    HostAddress localAddress;
     QString targetAddress;
     quint16 localPort;
     quint16 targetPort;
@@ -126,7 +126,7 @@ ParserResult parseArguments(Configure *configure, QString *errorMessage)
 
     QString localAddressStr = parser.value(localAddressOption);
     if (localAddressStr.isEmpty()) {
-        configure->localAddress.setAddress(QHostAddress::Any);
+        configure->localAddress.setAddress(HostAddress::Any);
     } else {
         configure->localAddress.setAddress(localAddressStr);
         if (configure->localAddress.isNull()) {

--- a/include/hostaddress.h
+++ b/include/hostaddress.h
@@ -1,0 +1,102 @@
+#ifndef QTNG_HOSTADDRESS_H
+#define QTNG_HOSTADDRESS_H
+
+#include <QtCore/qobject.h>
+#include <QtCore/QSharedDataPointer>
+#include <QtCore/QList>
+#include "config.h"
+
+
+QTNETWORKNG_NAMESPACE_BEGIN
+
+struct  IPv6Addr
+{
+public:
+    inline quint8 &operator [](int index) { return c[index]; }
+    inline quint8 operator [](int index) const { return c[index]; }
+    quint8 c[16];
+};
+
+typedef quint32 IPv4Address;
+typedef IPv6Addr IPv6Address;
+
+#ifdef Q_OS_WIN
+void initWinSock();
+void freeWinSock();
+#endif
+
+class HostAddressPrivate;
+class HostAddress
+{
+public:
+    enum SpecialAddress {
+        Null,
+        Broadcast,
+        LocalHost,
+        LocalHostIPv6,
+        Any,
+        AnyIPv6,
+        AnyIPv4
+    };
+    enum NetworkLayerProtocol {
+        IPv4Protocol = 1,
+        IPv6Protocol = 2,
+        AnyIPProtocol = 3,
+        UnknownNetworkLayerProtocol = -1
+    };
+    Q_ENUMS(NetworkLayerProtocol)
+
+    enum ConversionModeFlag {
+        ConvertV4MappedToIPv4 = 1,
+        ConvertV4CompatToIPv4 = 2,
+        ConvertUnspecifiedAddress = 4,
+        ConvertLocalHost = 8,
+        TolerantConversion = 0xff,
+        StrictConversion = 0
+    };
+    Q_DECLARE_FLAGS(ConversionMode, ConversionModeFlag)
+
+public:
+    HostAddress();
+    HostAddress(const HostAddress& copy);
+    HostAddress(SpecialAddress address);
+    ~HostAddress();
+
+    HostAddress &operator=(HostAddress &&other) noexcept
+    { swap(other); return *this; }
+    HostAddress &operator=(const HostAddress &other);
+    HostAddress &operator=(SpecialAddress address);
+
+    bool isEqual(const HostAddress &address, ConversionMode mode = TolerantConversion) const;
+    bool operator ==(const HostAddress &address) const;
+    bool operator ==(SpecialAddress address) const;
+
+    void swap(HostAddress &other) noexcept;
+    void clear();
+public:
+    void setAddress(const IPv4Address ipv4);
+    void setAddress(const IPv6Address &ipv6);
+    void setAddress(const quint8* ipv6);
+    bool setAddress(const QString &ipString);
+
+    bool isNull() const;
+    NetworkLayerProtocol protocol() const;
+    IPv4Address toIPv4Address(bool *ok) const;
+    IPv6Address toIPv6Address() const;
+
+    QString toString() const;
+
+    QString scopeId() const;
+    void setScopeId(const QString &id);
+
+    static QList<HostAddress> getHostAddressByName(const QString &hostName);
+
+private:
+    friend class HostAddressPrivate;
+    QSharedDataPointer<HostAddressPrivate> d;
+
+};
+
+QTNETWORKNG_NAMESPACE_END
+
+#endif // QTNG_HOSTADDRESS_H

--- a/include/hostaddress.h
+++ b/include/hostaddress.h
@@ -6,6 +6,9 @@
 #include <QtCore/QList>
 #include "config.h"
 
+#ifdef QT_NETWORK_LIB
+#include <QtNetwork>
+#endif
 
 QTNETWORKNG_NAMESPACE_BEGIN
 
@@ -60,6 +63,10 @@ public:
     HostAddress();
     HostAddress(const HostAddress& copy);
     HostAddress(SpecialAddress address);
+#ifdef QT_NETWORK_LIB
+    HostAddress(const QHostAddress& address);
+    HostAddress(QHostAddress::SpecialAddress address);
+#endif
     ~HostAddress();
 
     HostAddress &operator=(HostAddress &&other) noexcept

--- a/include/http_proxy.h
+++ b/include/http_proxy.h
@@ -24,7 +24,7 @@ public:
     ~HttpProxy();
 public:
     QSharedPointer<Socket> connect(const QString &remoteHost, quint16 port);
-    QSharedPointer<Socket> connect(const QHostAddress &remoteHost, quint16 port);
+    QSharedPointer<Socket> connect(const HostAddress &remoteHost, quint16 port);
 public:
     QString hostName() const;
     quint16 port() const;

--- a/include/kcp.h
+++ b/include/kcp.h
@@ -18,7 +18,7 @@ public:
         Loopback,
     };
 public:
-    explicit KcpSocket(Socket::NetworkLayerProtocol protocol = Socket::IPv4Protocol);
+    explicit KcpSocket(HostAddress::NetworkLayerProtocol protocol = HostAddress::IPv4Protocol);
     explicit KcpSocket(qintptr socketDescriptor);
     explicit KcpSocket(QSharedPointer<Socket> rawSocket);
     virtual ~KcpSocket();
@@ -36,23 +36,23 @@ public:
     Socket::SocketError error() const;
     QString errorString() const;
     bool isValid() const;
-    QHostAddress localAddress() const;
+    HostAddress localAddress() const;
     quint16 localPort() const;
-    QHostAddress peerAddress() const;
+    HostAddress peerAddress() const;
     QString peerName() const;
     quint16 peerPort() const;
     Socket::SocketType type() const;
     Socket::SocketState state() const;
-    Socket::NetworkLayerProtocol protocol() const;
+    HostAddress::NetworkLayerProtocol protocol() const;
 
     KcpSocket *accept();
-    KcpSocket *accept(const QHostAddress &addr, quint16 port);
+    KcpSocket *accept(const HostAddress &addr, quint16 port);
     KcpSocket *accept(const QString &hostName, quint16 port,
                                      QSharedPointer<SocketDnsCache> dnsCache = QSharedPointer<SocketDnsCache>());
 
-    bool bind(const QHostAddress &address, quint16 port = 0, Socket::BindMode mode = Socket::DefaultForPlatform);
+    bool bind(const HostAddress &address, quint16 port = 0, Socket::BindMode mode = Socket::DefaultForPlatform);
     bool bind(quint16 port = 0, Socket::BindMode mode = Socket::DefaultForPlatform);
-    bool connect(const QHostAddress &addr, quint16 port);
+    bool connect(const HostAddress &addr, quint16 port);
     bool connect(const QString &hostName, quint16 port, QSharedPointer<SocketDnsCache> dnsCache = QSharedPointer<SocketDnsCache>());
     void close();
     void abort();
@@ -69,20 +69,20 @@ public:
     qint32 send(const QByteArray &data);
     qint32 sendall(const QByteArray &data);
 
-    virtual bool filter(char *data, qint32 *len, QHostAddress *addr, quint16 *port);
-    qint32 udpSend(const char *data, qint32 size, const QHostAddress &addr, quint16 port);
-    qint32 udpSend(const QByteArray &packet, const QHostAddress &addr, quint16 port)
+    virtual bool filter(char *data, qint32 *len, HostAddress *addr, quint16 *port);
+    qint32 udpSend(const char *data, qint32 size, const HostAddress &addr, quint16 port);
+    qint32 udpSend(const QByteArray &packet, const HostAddress &addr, quint16 port)
         { return udpSend(packet.constData(), packet.size(), addr, port); }
 
-    static KcpSocket *createConnection(const QHostAddress &host, quint16 port, Socket::SocketError *error = nullptr,
-                                      int allowProtocol = Socket::IPv4Protocol | Socket::IPv6Protocol);
+    static KcpSocket *createConnection(const HostAddress &host, quint16 port, Socket::SocketError *error = nullptr,
+                                      int allowProtocol = HostAddress::IPv4Protocol | HostAddress::IPv6Protocol);
     static KcpSocket *createConnection(const QString &hostName, quint16 port, Socket::SocketError *error = nullptr,
                                   QSharedPointer<SocketDnsCache> dnsCache = QSharedPointer<SocketDnsCache>(),
-                                  int allowProtocol = Socket::IPv4Protocol | Socket::IPv6Protocol);
-    static KcpSocket *createServer(const QHostAddress &host, quint16 port, int backlog = 50);
+                                  int allowProtocol = HostAddress::IPv4Protocol | HostAddress::IPv6Protocol);
+    static KcpSocket *createServer(const HostAddress &host, quint16 port, int backlog = 50);
 private:
     // for create SlaveKcpSocket.
-    KcpSocket(KcpSocketPrivate *d, const QHostAddress &addr, const quint16 port, KcpSocket::Mode mode);
+    KcpSocket(KcpSocketPrivate *d, const HostAddress &addr, const quint16 port, KcpSocket::Mode mode);
     friend class SlaveKcpSocketPrivate;
 private:
     KcpSocketPrivate * const d_ptr;

--- a/include/socket.h
+++ b/include/socket.h
@@ -4,9 +4,9 @@
 #include <QtCore/qstring.h>
 #include <QtCore/qbytearray.h>
 #include <QtCore/qobject.h>
-#include <QtNetwork/qhostaddress.h>
 #include <QtNetwork/qhostinfo.h>
 
+#include "hostaddress.h"
 #include "private/eventloop_p.h"
 #include "locks.h"
 
@@ -18,6 +18,7 @@ QTNETWORKNG_NAMESPACE_BEGIN
 
 class SocketPrivate;
 class SocketDnsCache;
+class HostAddress;
 
 class Socket: public QObject
 {
@@ -32,12 +33,7 @@ public:
         UnknownSocketType = -1
     };
     Q_ENUMS(SocketType)
-    enum NetworkLayerProtocol {
-        IPv4Protocol = 1,
-        IPv6Protocol = 2,
-        UnknownNetworkLayerProtocol = -1
-    };
-    Q_ENUMS(NetworkLayerProtocol)
+
     enum SocketError {
         ConnectionRefusedError = 1,
         RemoteHostClosedError = 2,
@@ -105,27 +101,27 @@ public:
     };
     Q_DECLARE_FLAGS(BindMode, BindFlag)
 public:
-    explicit Socket(NetworkLayerProtocol protocol = IPv4Protocol, SocketType type = TcpSocket);
+    explicit Socket(HostAddress::NetworkLayerProtocol protocol = HostAddress::IPv4Protocol, SocketType type = TcpSocket);
     explicit Socket(qintptr socketDescriptor);
     virtual ~Socket();
 public:
     SocketError error() const;
     QString errorString() const;
     bool isValid() const;
-    QHostAddress localAddress() const;
+    HostAddress localAddress() const;
     quint16 localPort() const;
-    QHostAddress peerAddress() const;
+    HostAddress peerAddress() const;
     QString peerName() const;
     quint16 peerPort() const;
     qintptr fileno() const;
     SocketType type() const;
     SocketState state() const;
-    NetworkLayerProtocol protocol() const;
+    HostAddress::NetworkLayerProtocol protocol() const;
 
     Socket *accept();
-    bool bind(const QHostAddress &address, quint16 port = 0, BindMode mode = DefaultForPlatform);
+    bool bind(const HostAddress &address, quint16 port = 0, BindMode mode = DefaultForPlatform);
     bool bind(quint16 port = 0, BindMode mode = DefaultForPlatform);
-    bool connect(const QHostAddress &host, quint16 port);
+    bool connect(const HostAddress &host, quint16 port);
     bool connect(const QString &hostName, quint16 port, QSharedPointer<SocketDnsCache> dnsCache = QSharedPointer<SocketDnsCache>());
     void close();
     void abort();
@@ -137,23 +133,23 @@ public:
     qint32 recvall(char *data, qint32 size);
     qint32 send(const char *data, qint32 size);
     qint32 sendall(const char *data, qint32 size);
-    qint32 recvfrom(char *data, qint32 size, QHostAddress *addr, quint16 *port);
-    qint32 sendto(const char *data, qint32 size, const QHostAddress &addr, quint16 port);
+    qint32 recvfrom(char *data, qint32 size, HostAddress *addr, quint16 *port);
+    qint32 sendto(const char *data, qint32 size, const HostAddress &addr, quint16 port);
 
     QByteArray recvall(qint32 size);
     QByteArray recv(qint32 size);
     qint32 send(const QByteArray &data);
     qint32 sendall(const QByteArray &data);
-    QByteArray recvfrom(qint32 size, QHostAddress *addr, quint16 *port);
-    qint32 sendto(const QByteArray &data, const QHostAddress &addr, quint16 port);
+    QByteArray recvfrom(qint32 size, HostAddress *addr, quint16 *port);
+    qint32 sendto(const QByteArray &data, const HostAddress &addr, quint16 port);
 
-    static QList<QHostAddress> resolve(const QString &hostName);
-    static Socket *createConnection(const QHostAddress &host, quint16 port, Socket::SocketError *error = nullptr,
-                                  int allowProtocol = IPv4Protocol | IPv6Protocol);
+    static QList<HostAddress> resolve(const QString &hostName);
+    static Socket *createConnection(const HostAddress &host, quint16 port, Socket::SocketError *error = nullptr,
+                                  int allowProtocol = HostAddress::IPv4Protocol | HostAddress::IPv6Protocol);
     static Socket *createConnection(const QString &hostName, quint16 port, Socket::SocketError *error = nullptr,
                                   QSharedPointer<SocketDnsCache> dnsCache = QSharedPointer<SocketDnsCache>(),
-                                  int allowProtocol = IPv4Protocol | IPv6Protocol);
-    static Socket *createServer(const QHostAddress &host, quint16 port, int backlog = 50);
+                                  int allowProtocol = HostAddress::IPv4Protocol | HostAddress::IPv6Protocol);
+    static Socket *createServer(const HostAddress &host, quint16 port, int backlog = 50);
 private:
     SocketPrivate * const dd_ptr;
     Q_DECLARE_PRIVATE_D(dd_ptr, Socket)
@@ -191,7 +187,7 @@ public:
     SocketDnsCache();
     virtual ~SocketDnsCache();
 public:
-    QList<QHostAddress> resolve(const QString &hostName);
+    QList<HostAddress> resolve(const QString &hostName);
 private:
     SocketDnsCachePrivate * const d_ptr;
     Q_DECLARE_PRIVATE(SocketDnsCache)

--- a/include/socket_server.h
+++ b/include/socket_server.h
@@ -14,8 +14,8 @@ class BaseStreamServerPrivate;
 class BaseStreamServer
 {
 public:
-    BaseStreamServer(const QHostAddress &serverAddress, quint16 serverPort);
-    BaseStreamServer(quint16 serverPort) : BaseStreamServer(QHostAddress::Any, serverPort) {}
+    BaseStreamServer(const HostAddress &serverAddress, quint16 serverPort);
+    BaseStreamServer(quint16 serverPort) : BaseStreamServer(HostAddress::Any, serverPort) {}
     virtual ~BaseStreamServer();
 protected:
     // these two virtual functions should be overrided by subclass.
@@ -35,7 +35,7 @@ public:
     void *userData() const;
 public:
     quint16 serverPort() const;
-    QHostAddress serverAddress() const;
+    HostAddress serverAddress() const;
 public:
     QSharedPointer<Event> started;
     QSharedPointer<Event> stopped;
@@ -62,10 +62,10 @@ template<typename RequestHandler>
 class TcpServer: public BaseStreamServer
 {
 public:
-    TcpServer(const QHostAddress &serverAddress, quint16 serverPort)
+    TcpServer(const HostAddress &serverAddress, quint16 serverPort)
         : BaseStreamServer(serverAddress, serverPort) {}
     TcpServer(quint16 serverPort)
-        : BaseStreamServer(QHostAddress::Any, serverPort) {}
+        : BaseStreamServer(HostAddress::Any, serverPort) {}
 protected:
     virtual QSharedPointer<SocketLike> serverCreate() override;
     virtual void processRequest(QSharedPointer<SocketLike> request) override;
@@ -93,10 +93,10 @@ template<typename RequestHandler>
 class KcpServer: public BaseStreamServer
 {
 public:
-    KcpServer(const QHostAddress &serverAddress, quint16 serverPort)
+    KcpServer(const HostAddress &serverAddress, quint16 serverPort)
         :BaseStreamServer(serverAddress, serverPort) {}
     KcpServer(quint16 serverPort)
-        : BaseStreamServer(QHostAddress::Any, serverPort) {}
+        : BaseStreamServer(HostAddress::Any, serverPort) {}
 protected:
     virtual QSharedPointer<SocketLike> serverCreate() override;
     virtual void processRequest(QSharedPointer<SocketLike> request) override;
@@ -127,8 +127,8 @@ template<typename ServerType>
 class WithSsl: public ServerType
 {
 public:
-    WithSsl(const QHostAddress &serverAddress, quint16 serverPort);
-    WithSsl(const QHostAddress &serverAddress, quint16 serverPort, const SslConfiguration &configuration);
+    WithSsl(const HostAddress &serverAddress, quint16 serverPort);
+    WithSsl(const HostAddress &serverAddress, quint16 serverPort, const SslConfiguration &configuration);
     WithSsl(quint16 serverPort);
     WithSsl(quint16 serverPort, const SslConfiguration &configuration);
 public:
@@ -146,7 +146,7 @@ private:
 
 
 template<typename ServerType>
-WithSsl<ServerType>::WithSsl(const QHostAddress &serverAddress, quint16 serverPort)
+WithSsl<ServerType>::WithSsl(const HostAddress &serverAddress, quint16 serverPort)
     : ServerType(serverAddress, serverPort)
     , _sslHandshakeTimeout(5.0)
 {
@@ -155,7 +155,7 @@ WithSsl<ServerType>::WithSsl(const QHostAddress &serverAddress, quint16 serverPo
 
 
 template<typename ServerType>
-WithSsl<ServerType>::WithSsl(const QHostAddress &serverAddress, quint16 serverPort, const SslConfiguration &configuration)
+WithSsl<ServerType>::WithSsl(const HostAddress &serverAddress, quint16 serverPort, const SslConfiguration &configuration)
     : ServerType(serverAddress, serverPort)
     , _configuration(configuration)
     , _sslHandshakeTimeout(5.0)
@@ -164,7 +164,7 @@ WithSsl<ServerType>::WithSsl(const QHostAddress &serverAddress, quint16 serverPo
 
 template<typename ServerType>
 WithSsl<ServerType>::WithSsl(quint16 serverPort)
-    : ServerType(QHostAddress::Any, serverPort)
+    : ServerType(HostAddress::Any, serverPort)
     , _sslHandshakeTimeout(5.0)
 {
     _configuration = SslConfiguration::testPurpose("SslServer", "CN", "QtNetworkNg");
@@ -173,7 +173,7 @@ WithSsl<ServerType>::WithSsl(quint16 serverPort)
 
 template<typename ServerType>
 WithSsl<ServerType>::WithSsl(quint16 serverPort, const SslConfiguration &configuration)
-    : ServerType(QHostAddress::Any, serverPort)
+    : ServerType(HostAddress::Any, serverPort)
     , _configuration(configuration)
     , _sslHandshakeTimeout(5.0)
 {}
@@ -235,20 +235,20 @@ template<typename RequestHandler>
 class SslServer: public WithSsl<TcpServer<RequestHandler>>
 {
 public:
-    SslServer(const QHostAddress &serverAddress, quint16 serverPort);
-    SslServer(const QHostAddress &serverAddress, quint16 serverPort, const SslConfiguration &configuration);
+    SslServer(const HostAddress &serverAddress, quint16 serverPort);
+    SslServer(const HostAddress &serverAddress, quint16 serverPort, const SslConfiguration &configuration);
     SslServer(quint16 serverPort);
     SslServer(quint16 serverPort, const SslConfiguration &configuration);
 };
 
 
 template<typename RequestHandler>
-SslServer<RequestHandler>::SslServer(const QHostAddress &serverAddress, quint16 serverPort)
+SslServer<RequestHandler>::SslServer(const HostAddress &serverAddress, quint16 serverPort)
     : WithSsl<TcpServer<RequestHandler>>(serverAddress, serverPort) {}
 
 
 template<typename RequestHandler>
-SslServer<RequestHandler>::SslServer(const QHostAddress &serverAddress, quint16 serverPort, const SslConfiguration &configuration)
+SslServer<RequestHandler>::SslServer(const HostAddress &serverAddress, quint16 serverPort, const SslConfiguration &configuration)
     : WithSsl<TcpServer<RequestHandler>>(serverAddress, serverPort, configuration) {}
 
 
@@ -297,11 +297,11 @@ public:
     Socks5RequestHandler();
     virtual ~Socks5RequestHandler() override;
 protected:
-    virtual void doConnect(const QString &hostName, const QHostAddress &hostAddress, quint16 port);
-    bool sendConnectReply(const QHostAddress &hostAddress, quint16 port);
-    virtual void doFailed(const QString &hostName, const QHostAddress &hostAddress, quint16 port);
+    virtual void doConnect(const QString &hostName, const HostAddress &hostAddress, quint16 port);
+    bool sendConnectReply(const HostAddress &hostAddress, quint16 port);
+    virtual void doFailed(const QString &hostName, const HostAddress &hostAddress, quint16 port);
     bool sendFailedReply();
-    virtual void log(const QString &hostName, const QHostAddress &hostAddress, quint16 port, bool success);
+    virtual void log(const QString &hostName, const HostAddress &hostAddress, quint16 port, bool success);
 protected:
     virtual void handle() override;
 private:

--- a/include/socket_utils.h
+++ b/include/socket_utils.h
@@ -21,21 +21,21 @@ public:
     virtual Socket::SocketError error() const = 0;
     virtual QString errorString() const = 0;
     virtual bool isValid() const = 0;
-    virtual QHostAddress localAddress() const = 0;
+    virtual HostAddress localAddress() const = 0;
     virtual quint16 localPort() const = 0;
-    virtual QHostAddress peerAddress() const = 0;
+    virtual HostAddress peerAddress() const = 0;
     virtual QString peerName() const = 0;
     virtual quint16 peerPort() const = 0;
     virtual qintptr	fileno() const = 0;
     virtual Socket::SocketType type() const = 0;
     virtual Socket::SocketState state() const = 0;
-    virtual Socket::NetworkLayerProtocol protocol() const = 0;
+    virtual HostAddress::NetworkLayerProtocol protocol() const = 0;
 
     virtual QSharedPointer<SocketLike> accept() = 0;
     virtual Socket *acceptRaw() = 0;
-    virtual bool bind(const QHostAddress &address, quint16 port = 0, Socket::BindMode mode = Socket::DefaultForPlatform) = 0;
+    virtual bool bind(const HostAddress &address, quint16 port = 0, Socket::BindMode mode = Socket::DefaultForPlatform) = 0;
     virtual bool bind(quint16 port = 0, Socket::BindMode mode = Socket::DefaultForPlatform) = 0;
-    virtual bool connect(const QHostAddress &addr, quint16 port) = 0;
+    virtual bool connect(const HostAddress &addr, quint16 port) = 0;
     virtual bool connect(const QString &hostName, quint16 port, QSharedPointer<SocketDnsCache> dnsCache = QSharedPointer<SocketDnsCache>()) = 0;
 //    virtual void close() override = 0;  // from FileLike
     virtual void abort() = 0;

--- a/include/socks5_proxy.h
+++ b/include/socks5_proxy.h
@@ -59,7 +59,7 @@ public:
     ~Socks5Proxy();
 public:
     QSharedPointer<Socket> connect(const QString &remoteHost, quint16 port);
-    QSharedPointer<Socket> connect(const QHostAddress &remoteHost, quint16 port);
+    QSharedPointer<Socket> connect(const HostAddress &remoteHost, quint16 port);
     QSharedPointer<SocketLike> listen(quint16 port);
 
     bool isNull() const;

--- a/include/ssl.h
+++ b/include/ssl.h
@@ -161,7 +161,7 @@ public:
         NextProtocolNegotiationUnsupported = 2,
     };
 public:
-    SslSocket(Socket::NetworkLayerProtocol protocol=Socket::IPv4Protocol, const SslConfiguration &config = SslConfiguration());
+    SslSocket(HostAddress::NetworkLayerProtocol protocol=HostAddress::IPv4Protocol, const SslConfiguration &config = SslConfiguration());
     SslSocket(qintptr socketDescriptor, const SslConfiguration &config = SslConfiguration());
     SslSocket(QSharedPointer<Socket> rawSocket, const SslConfiguration &config = SslConfiguration());
     SslSocket(QSharedPointer<SocketLike> rawSocket, const SslConfiguration &config = SslConfiguration());
@@ -188,21 +188,21 @@ public:
     Socket::SocketError error() const;
     QString errorString() const;
     bool isValid() const;
-    QHostAddress localAddress() const;
+    HostAddress localAddress() const;
     quint16 localPort() const;
-    QHostAddress peerAddress() const;
+    HostAddress peerAddress() const;
     QString peerName() const;
     quint16 peerPort() const;
     virtual qintptr	fileno() const;
     Socket::SocketType type() const;
     Socket::SocketState state() const;
-    Socket::NetworkLayerProtocol protocol() const;
+    HostAddress::NetworkLayerProtocol protocol() const;
 
     SslSocket *accept();
     Socket *acceptRaw();
-    bool bind(const QHostAddress &address, quint16 port = 0, Socket::BindMode mode = Socket::DefaultForPlatform);
+    bool bind(const HostAddress &address, quint16 port = 0, Socket::BindMode mode = Socket::DefaultForPlatform);
     bool bind(quint16 port = 0, Socket::BindMode mode = Socket::DefaultForPlatform);
-    bool connect(const QHostAddress &addr, quint16 port);
+    bool connect(const HostAddress &addr, quint16 port);
     bool connect(const QString &hostName, quint16 port,
                  QSharedPointer<SocketDnsCache> dnsCache=QSharedPointer<SocketDnsCache>());
     void close();
@@ -220,16 +220,16 @@ public:
     qint32 send(const QByteArray &data);
     qint32 sendall(const QByteArray &data);
 
-    static SslSocket *createConnection(const QHostAddress &host, quint16 port,
+    static SslSocket *createConnection(const HostAddress &host, quint16 port,
                     const SslConfiguration &config = SslConfiguration(),
                     Socket::SocketError *error = nullptr,
-                    int allowProtocol = Socket::IPv4Protocol | Socket::IPv6Protocol);
+                    int allowProtocol = HostAddress::IPv4Protocol | HostAddress::IPv6Protocol);
     static SslSocket *createConnection(const QString &hostName, quint16 port,
                     const SslConfiguration &config = SslConfiguration(),
                     Socket::SocketError *error = nullptr,
                     QSharedPointer<SocketDnsCache> dnsCache = QSharedPointer<SocketDnsCache>(),
-                    int allowProtocol = Socket::IPv4Protocol | Socket::IPv6Protocol);
-    static SslSocket *createServer(const QHostAddress &host, quint16 port,
+                    int allowProtocol = HostAddress::IPv4Protocol | HostAddress::IPv6Protocol);
+    static SslSocket *createServer(const HostAddress &host, quint16 port,
                                                   const SslConfiguration &config = SslConfiguration(),
                                                   int backlog = 50);
 private:

--- a/qtnetworkng.pri
+++ b/qtnetworkng.pri
@@ -28,7 +28,8 @@ SOURCES += \
     $$PWD/src/socket_server.cpp \
     $$PWD/src/httpd.cpp \
     $$PWD/src/socks5_server.cpp \
-    $$PWD/src/random.cpp
+    $$PWD/src/random.cpp \
+    $$PWD/src/hostaddress.cpp
 
     
 PRIVATE_HEADERS += \
@@ -56,7 +57,8 @@ HEADERS += \
     $$PWD/include/kcp.h \
     $$PWD/include/socket_server.h \
     $$PWD/include/httpd.h \
-    $$PWD/include/random.h
+    $$PWD/include/random.h \
+    $$PWD/include/hostaddress.h
 
     
 win32 {

--- a/qtnetworkng.pri
+++ b/qtnetworkng.pri
@@ -1,4 +1,5 @@
 QT += core network
+QT -= gui
 
 CONFIG += c++11
 

--- a/qtnetworkng.pro
+++ b/qtnetworkng.pro
@@ -1,6 +1,3 @@
-QT += core network
-QT -= gui
-
 TARGET = qtnetworkng
 CONFIG += console staticlib
 CONFIG -= app_bundle

--- a/src/data_channel.cpp
+++ b/src/data_channel.cpp
@@ -192,7 +192,7 @@ public:
     void doSend();
     void doReceive();
     void doKeepalive();
-    QHostAddress getPeerAddress();
+    HostAddress getPeerAddress();
 
     const QSharedPointer<SocketLike> connection;
     Queue<WritingPacket> sendingQueue;
@@ -1105,21 +1105,21 @@ public:
     virtual Socket::SocketError error() const override;
     virtual QString errorString() const override;
     virtual bool isValid() const override;
-    virtual QHostAddress localAddress() const override;
+    virtual HostAddress localAddress() const override;
     virtual quint16 localPort() const override;
-    virtual QHostAddress peerAddress() const override;
+    virtual HostAddress peerAddress() const override;
     virtual QString peerName() const override;
     virtual quint16 peerPort() const override;
     virtual qintptr	fileno() const override;
     virtual Socket::SocketType type() const override;
     virtual Socket::SocketState state() const override;
-    virtual Socket::NetworkLayerProtocol protocol() const override;
+    virtual HostAddress::NetworkLayerProtocol protocol() const override;
 
     virtual Socket *acceptRaw() override;
     virtual QSharedPointer<SocketLike> accept() override;
-    virtual bool bind(const QHostAddress &address, quint16 port, Socket::BindMode mode) override;
+    virtual bool bind(const HostAddress &address, quint16 port, Socket::BindMode mode) override;
     virtual bool bind(quint16 port, Socket::BindMode mode) override;
-    virtual bool connect(const QHostAddress &addr, quint16 port) override;
+    virtual bool connect(const HostAddress &addr, quint16 port) override;
     virtual bool connect(const QString &hostName, quint16 port, QSharedPointer<SocketDnsCache> dnsCache) override;
     virtual void abort() override;
     virtual bool listen(int backlog) override;
@@ -1182,11 +1182,11 @@ bool SocketLikeImpl::isValid() const
 }
 
 
-QHostAddress SocketLikeImpl::localAddress() const
+HostAddress SocketLikeImpl::localAddress() const
 {
     QSharedPointer<SocketLike> backend = getBackend();
     if (backend.isNull()) {
-        return QHostAddress();
+        return HostAddress();
     } else {
         return backend->localAddress();
     }
@@ -1204,11 +1204,11 @@ quint16 SocketLikeImpl::localPort() const
 }
 
 
-QHostAddress SocketLikeImpl::peerAddress() const
+HostAddress SocketLikeImpl::peerAddress() const
 {
     QSharedPointer<SocketLike> backend = getBackend();
     if (backend.isNull()) {
-        return QHostAddress();
+        return HostAddress();
     } else {
         return backend->peerAddress();
     }
@@ -1270,11 +1270,11 @@ Socket::SocketState SocketLikeImpl::state() const
 }
 
 
-Socket::NetworkLayerProtocol SocketLikeImpl::protocol() const
+HostAddress::NetworkLayerProtocol SocketLikeImpl::protocol() const
 {
     QSharedPointer<SocketLike> backend = getBackend();
     if (backend.isNull()) {
-        return Socket::UnknownNetworkLayerProtocol;
+        return HostAddress::UnknownNetworkLayerProtocol;
     } else {
         return backend->protocol();
     }
@@ -1293,7 +1293,7 @@ QSharedPointer<SocketLike> SocketLikeImpl::accept()
 }
 
 
-bool SocketLikeImpl::bind(const QHostAddress &, quint16, Socket::BindMode)
+bool SocketLikeImpl::bind(const HostAddress &, quint16, Socket::BindMode)
 {
     return false;
 }
@@ -1305,7 +1305,7 @@ bool SocketLikeImpl::bind(quint16, Socket::BindMode)
 }
 
 
-bool SocketLikeImpl::connect(const QHostAddress &, quint16)
+bool SocketLikeImpl::connect(const HostAddress &, quint16)
 {
     return false;
 }

--- a/src/hostaddress.cpp
+++ b/src/hostaddress.cpp
@@ -12,6 +12,9 @@
     #include <ws2tcpip.h>
 #else
     #include <netinet/in.h>
+    #include <arpa/inet.h>
+    #include <sys/socket.h>
+	#include <netdb.h>
 #endif
 
 QTNETWORKNG_NAMESPACE_BEGIN
@@ -638,6 +641,34 @@ HostAddress::HostAddress(HostAddress::SpecialAddress address)
 {
     setAddress(address);
 }
+
+#ifdef QT_NETWORK_LIB
+HostAddress::HostAddress(const QHostAddress& address)
+    :d(new HostAddressPrivate())
+{
+    switch (address.protocol()){
+    case QAbstractSocket::IPv4Protocol:
+        setAddress(address.toIPv4Address());
+        break;
+    case QAbstractSocket::IPv6Protocol:
+        Q_IPV6ADDR a6;
+        a6 = address.toIPv6Address();
+        setAddress(a6.c);
+        break;
+    case QAbstractSocket::AnyIPProtocol:
+        setAddress(Any);
+        break;
+    case QAbstractSocket::UnknownNetworkLayerProtocol:
+        break;
+    }
+}
+
+HostAddress::HostAddress(QHostAddress::SpecialAddress address)
+    :d(new HostAddressPrivate())
+{
+    setAddress(static_cast<HostAddress::SpecialAddress>(address));
+}
+#endif
 
 HostAddress::~HostAddress()
 {

--- a/src/hostaddress.cpp
+++ b/src/hostaddress.cpp
@@ -1,0 +1,906 @@
+#include "../include/hostaddress.h"
+#include "../include/socket.h"
+#include "../include/private/socket_p.h"
+#include <QtCore/QSharedData>
+#include <QtCore/qendian.h>
+#include <QtCore/qlocale.h>
+#include <QtCore/qchar.h>
+#include <QtCore/QUrl>
+
+#ifdef Q_OS_WIN
+    #include <winsock2.h>
+    #include <ws2tcpip.h>
+#else
+    #include <netinet/in.h>
+#endif
+
+QTNETWORKNG_NAMESPACE_BEGIN
+
+#ifdef Q_OS_WIN
+static QAtomicInt refcount;
+void initWinSock()
+{
+    if(refcount.fetchAndAddAcquire(1) > 0) {
+        return;
+    }
+    WORD wVersionRequested;
+    WSADATA wsaData;
+    int err;
+
+    /* Use the MAKEWORD(lowbyte, highbyte) macro declared in Windef.h */
+    wVersionRequested = MAKEWORD(2, 2);
+
+    err = WSAStartup(wVersionRequested, &wsaData);
+    if (err != 0) {
+        /* Tell the user that we could not find a usable */
+        /* Winsock DLL.                                  */
+        qDebug("WSAStartup failed with error: %d\n", err);
+    }
+}
+
+void freeWinSock()
+{
+    if(refcount.fetchAndSubAcquire(1) > 0) {
+        return;
+    }
+    WSACleanup();
+}
+#endif
+
+
+typedef QVarLengthArray<char, 64> Buffer;
+static const QChar *checkedToAscii(Buffer &buffer, const QChar *begin, const QChar *end);
+static bool parseIp4(IPv4Address &address, const QChar *begin, const QChar *end);
+static bool parseIp4Internal(IPv4Address &address, const char *ptr, bool acceptLeadingZero);
+static const QChar *parseIp6(IPv6Address &address, const QChar *begin, const QChar *end);
+static bool parseIp6(const QString &address, IPv6Address &addr, QString *scopeId);
+static unsigned long long qstrtoull(const char * nptr, const char **endptr, int base, bool *ok);
+static unsigned long long qt_strtoull(const char * nptr, char **endptr, int base);
+static bool convertToIpv4(IPv4Address& a, const IPv6Address& a6, const HostAddress::ConversionMode mode);
+static QString qulltoa(qulonglong l, int base, const QChar _zero);
+static QString number(quint8 val, int base = 10);
+
+unsigned long long qt_strtoull(const char * nptr, char **endptr, int base)
+{
+    const char *s;
+    unsigned long long acc;
+    char c;
+    unsigned long long cutoff;
+    int neg, any, cutlim;
+
+    /*
+     * See strtoq for comments as to the logic used.
+     */
+    s = nptr;
+    do {
+        c = *s++;
+    } while (isspace(c));
+    if (c == '-') {
+        neg = 1;
+        c = *s++;
+    } else {
+        neg = 0;
+        if (c == '+')
+            c = *s++;
+    }
+    if ((base == 0 || base == 16) &&
+        c == '0' && (*s == 'x' || *s == 'X') &&
+        ((s[1] >= '0' && s[1] <= '9') ||
+        (s[1] >= 'A' && s[1] <= 'F') ||
+        (s[1] >= 'a' && s[1] <= 'f'))) {
+        c = s[1];
+        s += 2;
+        base = 16;
+    }
+    if (base == 0)
+        base = c == '0' ? 8 : 10;
+    acc = any = 0;
+    if (base < 2 || base > 36)
+        goto noconv;
+
+    cutoff = ULLONG_MAX / base;
+    cutlim = ULLONG_MAX % base;
+    for ( ; ; c = *s++) {
+        if (c >= '0' && c <= '9')
+            c -= '0';
+        else if (c >= 'A' && c <= 'Z')
+            c -= 'A' - 10;
+        else if (c >= 'a' && c <= 'z')
+            c -= 'a' - 10;
+        else
+            break;
+        if (c >= base)
+            break;
+        if (any < 0 || acc > cutoff || (acc == cutoff && c > cutlim))
+            any = -1;
+        else {
+            any = 1;
+            acc *= base;
+            acc += c;
+        }
+    }
+    if (any < 0) {
+        acc = ULLONG_MAX;
+        errno = ERANGE;
+    } else if (!any) {
+noconv:
+        errno = EINVAL;
+    } else if (neg)
+        acc = (unsigned long long) -(long long)acc;
+    if (endptr != NULL)
+                *endptr = const_cast<char *>(any ? s - 1 : nptr);
+    return (acc);
+}
+
+static unsigned long long qstrtoull(const char * nptr, const char **endptr, int base, bool *ok)
+{
+    // strtoull accepts negative numbers. We don't.
+    // Use a different variable so we pass the original nptr to strtoul
+    // (we need that so endptr may be nptr in case of failure)
+    const char *begin = nptr;
+    while (isspace(*begin))
+            ++begin;
+    if (*begin == '-') {
+        *ok = false;
+        return 0;
+    }
+
+    *ok = true;
+    errno = 0;
+    char *endptr2 = nullptr;
+    unsigned long long result = qt_strtoull(nptr, &endptr2, base);
+    if (endptr)
+        *endptr = endptr2;
+    if ((result == 0 || result == std::numeric_limits<unsigned long long>::max())
+            && (errno || endptr2 == nptr)) {
+        *ok = false;
+        return 0;
+    }
+    return result;
+}
+
+static const QChar *checkedToAscii(Buffer &buffer, const QChar *begin, const QChar *end)
+{
+    const ushort *const ubegin = reinterpret_cast<const ushort *>(begin);
+    const ushort *const uend = reinterpret_cast<const ushort *>(end);
+    const ushort *src = ubegin;
+
+    buffer.resize(uend - ubegin + 1);
+    char *dst = buffer.data();
+
+    while (src != uend) {
+        if (*src >= 0x7f)
+            return reinterpret_cast<const QChar *>(src);
+        *dst++ = *src++;
+    }
+    *dst = '\0';
+    return nullptr;
+}
+
+static bool parseIp4(IPv4Address &address, const QChar *begin, const QChar *end)
+{
+    Q_ASSERT(begin != end);
+    Buffer buffer;
+    if (checkedToAscii(buffer, begin, end))
+        return false;
+
+    const char *ptr = buffer.data();
+    return parseIp4Internal(address, ptr, true);
+}
+
+static bool parseIp4Internal(IPv4Address &address, const char *ptr, bool acceptLeadingZero)
+{
+    address = 0;
+    int dotCount = 0;
+    while (dotCount < 4) {
+        if (!acceptLeadingZero && *ptr == '0' &&
+                ptr[1] != '.' && ptr[1] != '\0')
+            return false;
+
+        const char *endptr;
+        bool ok;
+        quint64 ll = qstrtoull(ptr, &endptr, 0, &ok);
+        quint32 x = ll;
+        if (!ok || endptr == ptr || ll != x)
+            return false;
+
+        if (*endptr == '.' || dotCount == 3) {
+            if (x & ~0xff)
+                return false;
+            address <<= 8;
+        } else if (dotCount == 2) {
+            if (x & ~0xffff)
+                return false;
+            address <<= 16;
+        } else if (dotCount == 1) {
+            if (x & ~0xffffff)
+                return false;
+            address <<= 24;
+        }
+        address |= x;
+
+        if (dotCount == 3 && *endptr != '\0')
+            return false;
+        else if (dotCount == 3 || *endptr == '\0')
+            return true;
+        if (*endptr != '.')
+            return false;
+
+        ++dotCount;
+        ptr = endptr + 1;
+    }
+    return false;
+}
+
+static const QChar *parseIp6(IPv6Address &address, const QChar *begin, const QChar *end)
+{
+    Q_ASSERT(begin != end);
+    Buffer buffer;
+    const QChar *ret = checkedToAscii(buffer, begin, end);
+    if (ret)
+        return ret;
+
+    const char *ptr = buffer.data();
+
+    // count the colons
+    int colonCount = 0;
+    int dotCount = 0;
+    while (*ptr) {
+        if (*ptr == ':')
+            ++colonCount;
+        if (*ptr == '.')
+            ++dotCount;
+        ++ptr;
+    }
+    // IPv4-in-IPv6 addresses are stricter in what they accept
+    if (dotCount != 0 && dotCount != 3)
+        return end;
+
+    memset(&address, 0, sizeof address);
+    if (colonCount == 2 && end - begin == 2) // "::"
+        return nullptr;
+
+    // if there's a double colon ("::"), this is how many zeroes it means
+    int zeroWordsToFill;
+    ptr = buffer.data();
+
+    // there are two cases where 8 colons are allowed: at the ends
+    // so test that before the colon-count test
+    if ((ptr[0] == ':' && ptr[1] == ':') ||
+            (ptr[end - begin - 2] == ':' && ptr[end - begin - 1] == ':')) {
+        zeroWordsToFill = 9 - colonCount;
+    } else if (colonCount < 2 || colonCount > 7) {
+        return end;
+    } else {
+        zeroWordsToFill = 8 - colonCount;
+    }
+    if (dotCount)
+        --zeroWordsToFill;
+
+    int pos = 0;
+    while (pos < 15) {
+        if (*ptr == ':') {
+            // empty field, we hope it's "::"
+            if (zeroWordsToFill < 1)
+                return begin + (ptr - buffer.data());
+            if (pos == 0 || pos == colonCount * 2) {
+                if (ptr[0] == '\0' || ptr[1] != ':')
+                    return begin + (ptr - buffer.data());
+                ++ptr;
+            }
+            pos += zeroWordsToFill * 2;
+            zeroWordsToFill = 0;
+            ++ptr;
+            continue;
+        }
+
+        const char *endptr;
+        bool ok;
+        quint64 ll = qstrtoull(ptr, &endptr, 16, &ok);
+        quint16 x = ll;
+
+        // Reject malformed fields:
+        // - failed to parse
+        // - too many hex digits
+        if (!ok || endptr > ptr + 4)
+            return begin + (ptr - buffer.data());
+
+        if (*endptr == '.') {
+            // this could be an IPv4 address
+            // it's only valid in the last element
+            if (pos != 12)
+                return begin + (ptr - buffer.data());
+
+            IPv4Address ip4;
+            if (!parseIp4Internal(ip4, ptr, false))
+                return begin + (ptr - buffer.data());
+
+            address[12] = ip4 >> 24;
+            address[13] = ip4 >> 16;
+            address[14] = ip4 >> 8;
+            address[15] = ip4;
+            return nullptr;
+        }
+
+        address[pos++] = x >> 8;
+        address[pos++] = x & 0xff;
+
+        if (*endptr == '\0')
+            break;
+        if (*endptr != ':')
+            return begin + (endptr - buffer.data());
+        ptr = endptr + 1;
+    }
+    return pos == 16 ? nullptr : end;
+}
+
+/// parses v4-mapped addresses or the AnyIPv6 address and stores in \a a;
+/// returns true if the address was one of those
+static bool convertToIpv4(IPv4Address& a, const IPv6Address& a6, const HostAddress::ConversionMode mode)
+{
+    if (mode == HostAddress::StrictConversion)
+        return false;
+
+    const uchar *ptr = a6.c;
+    if (qFromUnaligned<quint64>(ptr) != 0)
+        return false;
+
+    const quint32 mid = qFromBigEndian<quint32>(ptr + 8);
+    if ((mid == 0xffff) && (mode & HostAddress::ConvertV4MappedToIPv4)) {
+        a = qFromBigEndian<quint32>(ptr + 12);
+        return true;
+    }
+    if (mid != 0)
+        return false;
+
+    const quint32 low = qFromBigEndian<quint32>(ptr + 12);
+    if ((low == 0) && (mode & HostAddress::ConvertUnspecifiedAddress)) {
+        a = 0;
+        return true;
+    }
+    if ((low == 1) && (mode & HostAddress::ConvertLocalHost)) {
+        a = INADDR_LOOPBACK;
+        return true;
+    }
+    if ((low != 1) && (mode & HostAddress::ConvertV4CompatToIPv4)) {
+        a = low;
+        return true;
+    }
+    return false;
+}
+
+static QString qulltoa(qulonglong l, int base, const QChar _zero)
+{
+    ushort buff[65]; // length of MAX_ULLONG in base 2
+    ushort *p = buff + 65;
+
+    if (base != 10 || _zero.unicode() == '0') {
+        while (l != 0) {
+            int c = l % base;
+
+            --p;
+
+            if (c < 10)
+                *p = '0' + c;
+            else
+                *p = c - 10 + 'a';
+
+            l /= base;
+        }
+    }
+    else {
+        while (l != 0) {
+            int c = l % base;
+
+            *(--p) = _zero.unicode() + c;
+
+            l /= base;
+        }
+    }
+
+    return QString(reinterpret_cast<QChar *>(p), 65 - (p - buff));
+}
+
+static QString number(quint8 val, int base)
+{
+    QChar zero(0x30);
+    return val ? qulltoa(val, base, zero) : zero;
+}
+
+static QChar toHex(uchar c)
+{
+    return QChar::fromLatin1("0123456789abcdef"[c & 0xF]);
+}
+
+static void IPAddresstoString(QString &appendTo, IPv4Address address)
+{
+    appendTo += QStringLiteral("%1.%2.%3.%4").arg(number(address >> 24, 10)).arg(number(address >> 16, 10)) \
+                    .arg(number(address >> 8, 10)).arg(number(address, 10));
+}
+
+static void IPAddresstoString(QString &appendTo, const IPv6Address address)
+{
+    // the longest IPv6 address possible is:
+    //   "1111:2222:3333:4444:5555:6666:255.255.255.255"
+    // however, this function never generates that. The longest it does
+    // generate without an IPv4 address is:
+    //   "1111:2222:3333:4444:5555:6666:7777:8888"
+    // and the longest with an IPv4 address is:
+    //   "::ffff:255.255.255.255"
+    static const int Ip6AddressMaxLen = sizeof "1111:2222:3333:4444:5555:6666:7777:8888";
+    static const int Ip6WithIp4AddressMaxLen = sizeof "::ffff:255.255.255.255";
+
+    // check for the special cases
+    const quint64 zeroes[] = { 0, 0 };
+    bool embeddedIp4 = false;
+
+    // we consider embedded IPv4 for:
+    //  ::ffff:x.x.x.x
+    //  ::x.x.x.y  except if the x are 0 too
+    if (memcmp(&address, zeroes, 10) == 0) {
+        if (address[10] == 0xff && address[11] == 0xff) {
+            embeddedIp4 = true;
+        } else if (address[10] == 0 && address[11] == 0) {
+            if (address[12] != 0 || address[13] != 0 || address[14] != 0) {
+                embeddedIp4 = true;
+            } else if (address[15] == 0) {
+                appendTo.append(QLatin1String("::"));
+                return;
+            }
+        }
+    }
+
+    // QString::reserve doesn't shrink, so it's fine to us
+    appendTo.reserve(appendTo.size() +
+                     (embeddedIp4 ? Ip6WithIp4AddressMaxLen : Ip6AddressMaxLen));
+
+    // for finding where to place the "::"
+    int zeroRunLength = 0; // in octets
+    int zeroRunOffset = 0; // in octets
+    for (int i = 0; i < 16; i += 2) {
+        if (address[i] == 0 && address[i + 1] == 0) {
+            // found a zero, scan forward to see how many more there are
+            int j;
+            for (j = i; j < 16; j += 2) {
+                if (address[j] != 0 || address[j+1] != 0)
+                    break;
+            }
+
+            if (j - i > zeroRunLength) {
+                zeroRunLength = j - i;
+                zeroRunOffset = i;
+                i = j;
+            }
+        }
+    }
+
+    const QChar colon = u':';
+    if (zeroRunLength < 4)
+        zeroRunOffset = -1;
+    else if (zeroRunOffset == 0)
+        appendTo.append(colon);
+
+    for (int i = 0; i < 16; i += 2) {
+        if (i == zeroRunOffset) {
+            appendTo.append(colon);
+            i += zeroRunLength - 2;
+            continue;
+        }
+
+        if (i == 12 && embeddedIp4) {
+            IPv4Address ip4 = address[12] << 24 |
+                              address[13] << 16 |
+                              address[14] << 8 |
+                              address[15];
+            IPAddresstoString(appendTo, ip4);
+            return;
+        }
+
+        if (address[i]) {
+            if (address[i] >> 4) {
+                appendTo.append(toHex(address[i] >> 4));
+                appendTo.append(toHex(address[i] & 0xf));
+                appendTo.append(toHex(address[i + 1] >> 4));
+                appendTo.append(toHex(address[i + 1] & 0xf));
+            } else if (address[i] & 0xf) {
+                appendTo.append(toHex(address[i] & 0xf));
+                appendTo.append(toHex(address[i + 1] >> 4));
+                appendTo.append(toHex(address[i + 1] & 0xf));
+            }
+        } else if (address[i + 1] >> 4) {
+            appendTo.append(toHex(address[i + 1] >> 4));
+            appendTo.append(toHex(address[i + 1] & 0xf));
+        } else {
+            appendTo.append(toHex(address[i + 1] & 0xf));
+        }
+
+        if (i != 14)
+            appendTo.append(colon);
+    }
+}
+
+class HostAddressPrivate : public QSharedData
+{
+public:
+    HostAddressPrivate();
+
+    void setAddress(const IPv4Address ipv4_ = 0);
+    void setAddress(const IPv6Address ipv6);
+    bool parse(const QString &ipString);
+    void clear();
+
+    QString scopeId;
+
+    union {
+        IPv6Address a6;
+        struct { quint64 c[2]; } a6_64;
+        struct { quint32 c[4]; } a6_32;
+    }ipv6;// IPv6 address
+    IPv4Address ipv4;    // IPv4 address
+    qint8 protocol;
+
+    friend class HostAddress;
+};
+
+HostAddressPrivate::HostAddressPrivate()
+    : ipv4(0)
+    , protocol(HostAddress::UnknownNetworkLayerProtocol)
+{
+    memset(&ipv6, 0, sizeof(ipv6));
+}
+
+void HostAddressPrivate::setAddress(const IPv4Address ipv4_)
+{
+    ipv4 = ipv4_;
+    protocol = HostAddress::IPv4Protocol;
+
+    //create mapped address, except for a_ == 0 (any)
+    ipv6.a6_64.c[0] = 0;
+    if (ipv4) {
+        ipv6.a6_32.c[2] = qToBigEndian(0xffff);
+        ipv6.a6_32.c[3] = qToBigEndian(ipv4);
+    } else {
+        ipv6.a6_64.c[1] = 0;
+    }
+}
+
+void HostAddressPrivate::setAddress(const IPv6Address ipv6_)
+{
+    protocol = HostAddress::IPv6Protocol;
+    memcpy(&ipv6.a6, &ipv6_, sizeof(ipv6));
+    ipv4 = 0;
+
+
+    convertToIpv4(ipv4, ipv6.a6, HostAddress::ConversionMode(HostAddress::ConvertV4MappedToIPv4)
+                  | HostAddress::ConversionMode(HostAddress::ConvertUnspecifiedAddress));
+}
+
+void HostAddressPrivate::clear()
+{
+    ipv4 = 0;
+    protocol = HostAddress::UnknownNetworkLayerProtocol;
+    memset(&ipv6, 0, sizeof(ipv6));
+}
+
+
+static bool parseIp6(const QString &address, IPv6Address &addr, QString *scopeId)
+{
+    QStringRef tmp(&address);
+    int scopeIdPos = tmp.lastIndexOf(QLatin1Char('%'));
+    if (scopeIdPos != -1) {
+        *scopeId = tmp.mid(scopeIdPos + 1).toString();
+        tmp.chop(tmp.size() - scopeIdPos);
+    } else {
+        scopeId->clear();
+    }
+    return parseIp6(addr, tmp.constBegin(), tmp.constEnd()) == nullptr;
+}
+
+bool HostAddressPrivate::parse(const QString &ipString)
+{
+    protocol = HostAddress::UnknownNetworkLayerProtocol;
+    QString simpleStr = ipString.simplified();
+    if (simpleStr.isEmpty())
+        return false;
+
+    // All IPv6 addresses contain a ':', and may contain a '.'.
+    if (simpleStr.contains(QLatin1Char(':'))) {
+        IPv6Address maybeIp6;
+        if (parseIp6(simpleStr, maybeIp6, &scopeId)) {
+            setAddress(maybeIp6);
+            return true;
+        }
+    }
+
+    quint32 maybeIp4 = 0;
+    if (parseIp4(maybeIp4, simpleStr.constBegin(), simpleStr.constEnd())) {
+        setAddress(maybeIp4);
+        return true;
+    }
+
+    return false;
+}
+
+HostAddress::HostAddress()
+    :d(new HostAddressPrivate())
+{
+
+}
+
+HostAddress::HostAddress(const HostAddress &copy)
+    :d(copy.d)
+{
+
+}
+
+HostAddress::HostAddress(HostAddress::SpecialAddress address)
+    :d(new HostAddressPrivate())
+{
+    setAddress(address);
+}
+
+HostAddress::~HostAddress()
+{
+
+}
+
+HostAddress &HostAddress::operator=(const HostAddress &address)
+{
+    d = address.d;
+    return *this;
+}
+
+HostAddress &HostAddress::operator=(SpecialAddress address)
+{
+    setAddress(address);
+    return *this;
+}
+
+bool HostAddress::isEqual(const HostAddress &other, ConversionMode mode) const
+{
+    if (d == other.d)
+        return true;
+
+    if (d->protocol == IPv4Protocol) {
+        switch (other.d->protocol) {
+        case IPv4Protocol:
+            return d->ipv4 == other.d->ipv4;
+        case IPv6Protocol:
+            quint32 a4;
+            return convertToIpv4(a4, other.d->ipv6.a6, mode) && (a4 == d->ipv4);
+        case AnyIPProtocol:
+            return (mode & ConvertUnspecifiedAddress) && d->ipv4 == 0;
+        case UnknownNetworkLayerProtocol:
+            return false;
+        }
+    }
+
+    if (d->protocol == IPv6Protocol) {
+        switch (other.d->protocol) {
+        case IPv4Protocol:
+            quint32 a4;
+            return convertToIpv4(a4, d->ipv6.a6, mode) && (a4 == other.d->ipv4);
+        case IPv6Protocol:
+            return memcmp(&d->ipv6, &other.d->ipv6, sizeof(IPv6Addr)) == 0;
+        case AnyIPProtocol:
+            return (mode & ConvertUnspecifiedAddress)
+                && (other.d->ipv6.a6_64.c[0] == 0) && (other.d->ipv6.a6_64.c[1] == 0);
+        case UnknownNetworkLayerProtocol:
+            return false;
+        }
+    }
+
+    if ((d->protocol == HostAddress::AnyIPProtocol)
+        && (mode & HostAddress::ConvertUnspecifiedAddress)) {
+        switch (other.d->protocol) {
+        case IPv4Protocol:
+            return other.d->ipv4 == 0;
+        case IPv6Protocol:
+            return (other.d->ipv6.a6_64.c[0] == 0) && (other.d->ipv6.a6_64.c[1] == 0);
+        default:
+            break;
+        }
+    }
+
+    return d->protocol == other.d->protocol;
+}
+
+bool HostAddress::operator ==(const HostAddress &other) const
+{
+    return d == other.d || isEqual(other, StrictConversion);
+}
+
+bool HostAddress::operator ==(SpecialAddress other) const
+{
+    quint32 ip4 = INADDR_ANY;
+    switch (other) {
+    case Null:
+        return d->protocol == UnknownNetworkLayerProtocol;
+
+    case Broadcast:
+        ip4 = INADDR_BROADCAST;
+        break;
+
+    case LocalHost:
+        ip4 = INADDR_LOOPBACK;
+        break;
+
+    case Any:
+        return d->protocol == AnyIPProtocol;
+
+    case AnyIPv4:
+        break;
+
+    case LocalHostIPv6:
+    case AnyIPv6:
+        if (d->protocol == IPv6Protocol) {
+            quint64 second = quint8(other == LocalHostIPv6);  // 1 for localhost, 0 for any
+            return d->ipv6.a6_64.c[0] == 0 && d->ipv6.a6_64.c[1] == qToBigEndian(second);
+        }
+        return false;
+    }
+
+    // common IPv4 part
+    return d->protocol == IPv4Protocol && d->ipv4 == ip4;
+}
+
+void HostAddress::swap(HostAddress &other) noexcept
+{
+    d.swap(other.d);
+}
+
+void HostAddress::clear()
+{
+    d.detach();
+    d->clear();
+}
+
+void HostAddress::setAddress(const IPv4Address ipv4)
+{
+    d.detach();
+    d->setAddress(ipv4);
+}
+
+void HostAddress::setAddress(const IPv6Address &ipv6)
+{
+    d.detach();
+    d->setAddress(ipv6);
+}
+
+void HostAddress::setAddress(const quint8* ipv6)
+{
+    IPv6Address ip;
+    memcpy(&ip, ipv6, sizeof(ip));
+
+    d.detach();
+    d->setAddress(ip);
+}
+
+bool HostAddress::setAddress(const QString &ipString)
+{
+    d.detach();
+    return d->parse(ipString);
+}
+
+bool HostAddress::isNull() const
+{
+    return d->protocol == HostAddress::UnknownNetworkLayerProtocol;
+}
+
+HostAddress::NetworkLayerProtocol HostAddress::protocol() const
+{
+    return HostAddress::NetworkLayerProtocol(d->protocol);
+}
+
+IPv4Address HostAddress::toIPv4Address(bool *ok) const
+{
+    quint32 dummy;
+    if (ok)
+        *ok = d->protocol == HostAddress::IPv4Protocol || d->protocol == HostAddress::AnyIPProtocol
+              || (d->protocol == HostAddress::IPv6Protocol
+                  && convertToIpv4(dummy, d->ipv6.a6, HostAddress::ConversionMode(HostAddress::ConvertV4MappedToIPv4)
+                                                                | HostAddress::ConversionMode(HostAddress::ConvertUnspecifiedAddress)));
+    return d->ipv4;
+}
+
+IPv6Address HostAddress::toIPv6Address() const
+{
+    return d->ipv6.a6;
+}
+
+QString HostAddress::toString() const
+{
+    QString s;
+    if (d->protocol == HostAddress::IPv4Protocol
+        || d->protocol == HostAddress::AnyIPProtocol) {
+        quint32 i = toIPv4Address(nullptr);
+        IPAddresstoString(s, i);
+    } else if (d->protocol == HostAddress::IPv6Protocol) {
+        IPAddresstoString(s, d->ipv6.a6);
+        if (!d->scopeId.isEmpty())
+            s.append(QLatin1Char('%') + d->scopeId);
+    }
+    return s;
+}
+
+QString HostAddress::scopeId() const
+{
+    return (d->protocol == IPv6Protocol) ? d->scopeId : QString();
+}
+
+void HostAddress::setScopeId(const QString &id)
+{
+    d.detach();
+    if (d->protocol == IPv6Protocol)
+        d->scopeId = id;
+}
+
+QList<HostAddress> HostAddress::getHostAddressByName(const QString &hostName)
+{
+    // IDN support
+    QByteArray aceHostname = QUrl::toAce(hostName);
+    if (aceHostname.isEmpty()) {
+        return QList<HostAddress>();
+    }
+
+#ifdef Q_OS_WIN
+    initWinSock();
+#endif
+
+    addrinfo *res = nullptr;
+    struct addrinfo hints;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = PF_UNSPEC;
+#ifdef Q_ADDRCONFIG
+    hints.ai_flags = Q_ADDRCONFIG;
+#endif
+
+    int result = getaddrinfo(aceHostname.constData(), nullptr, &hints, &res);
+# ifdef Q_ADDRCONFIG
+    if (result == EAI_BADFLAGS) {
+        // if the lookup failed with AI_ADDRCONFIG set, try again without it
+        hints.ai_flags = 0;
+        result = getaddrinfo(aceHostname.constData(), nullptr, &hints, &res);
+    }
+# endif
+
+    QList<HostAddress> addresses;
+    if (result == 0) {
+        addrinfo *node = res;
+
+        while (node) {
+            switch (node->ai_family) {
+            case AF_INET: {
+                HostAddress addr;
+                addr.setAddress(ntohl(((sockaddr_in *) node->ai_addr)->sin_addr.s_addr));
+                if (!addresses.contains(addr))
+                    addresses.append(addr);
+                break;
+            }
+            case AF_INET6: {
+                HostAddress addr;
+                sockaddr_in6 *sa6 = (sockaddr_in6 *) node->ai_addr;
+                addr.setAddress(sa6->sin6_addr.s6_addr);
+                if (sa6->sin6_scope_id)
+                    addr.setScopeId(QString::number(sa6->sin6_scope_id));
+                if (!addresses.contains(addr))
+                    addresses.append(addr);
+                break;
+            }
+            default:
+                qWarning() << "Unknown address type when get hostname";
+            }
+            node = node->ai_next;
+        }
+        if (addresses.isEmpty()) {
+            qWarning() << "Unknown address type when get hostname";
+        }
+        freeaddrinfo(res);
+    }
+#ifdef Q_OS_WIN
+    freeWinSock();
+#endif
+    return addresses;
+}
+
+QTNETWORKNG_NAMESPACE_END

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -923,6 +923,8 @@ QSharedPointer<SocketLike> ConnectionPool::newConnectionForUrl(const QUrl &url, 
         }
     }
 
+
+
     if (rawSocket.isNull() || !rawSocket->isValid()) {
         *error = new ConnectionError();
         return QSharedPointer<SocketLike>();

--- a/src/http_proxy.cpp
+++ b/src/http_proxy.cpp
@@ -138,13 +138,13 @@ QSharedPointer<Socket> HttpProxy::connect(const QString &remoteHost, quint16 por
 }
 
 
-QSharedPointer<Socket> HttpProxy::connect(const QHostAddress &remoteHost, quint16 port)
+QSharedPointer<Socket> HttpProxy::connect(const HostAddress &remoteHost, quint16 port)
 {
     if (remoteHost.isNull()) {
         return QSharedPointer<Socket>();
     }
     QString hostName;
-    if (remoteHost.protocol() == QAbstractSocket::IPv6Protocol) {
+    if (remoteHost.protocol() == HostAddress::IPv6Protocol) {
         hostName = QStringLiteral("[%1]").arg(remoteHost.toString());
     } else {
         hostName = remoteHost.toString();

--- a/src/kcp.cpp
+++ b/src/kcp.cpp
@@ -30,20 +30,20 @@ public:
     virtual Socket::SocketError getError() const = 0;
     virtual QString getErrorString() const = 0;
     virtual bool isValid() const = 0;
-    virtual QHostAddress localAddress() const = 0;
+    virtual HostAddress localAddress() const = 0;
     virtual quint16 localPort() const = 0;
-    QHostAddress peerAddress() const;
+    HostAddress peerAddress() const;
     QString peerName() const;
     quint16 peerPort() const;
     Socket::SocketType type() const;
-    virtual Socket::NetworkLayerProtocol protocol() const = 0;
+    virtual HostAddress::NetworkLayerProtocol protocol() const = 0;
 public:
     virtual KcpSocket *accept() = 0;
-    virtual KcpSocket *accept(const QHostAddress &addr, quint16 port) = 0;
+    virtual KcpSocket *accept(const HostAddress &addr, quint16 port) = 0;
     virtual KcpSocket *accept(const QString &hostName, quint16 port, QSharedPointer<SocketDnsCache> dnsCache) = 0;
-    virtual bool bind(const QHostAddress &address, quint16 port, Socket::BindMode mode) = 0;
+    virtual bool bind(const HostAddress &address, quint16 port, Socket::BindMode mode) = 0;
     virtual bool bind(quint16 port, Socket::BindMode mode) = 0;
-    virtual bool connect(const QHostAddress &addr, quint16 port) = 0;
+    virtual bool connect(const HostAddress &addr, quint16 port) = 0;
     virtual bool connect(const QString &hostName, quint16 port, QSharedPointer<SocketDnsCache> dnsCache) = 0;
     virtual bool close(bool force) = 0;
     virtual bool listen(int backlog) = 0;
@@ -57,7 +57,7 @@ public:
     void updateKcp();
     void doUpdate();
     virtual qint32 rawSend(const char *data, qint32 size) = 0;
-    virtual qint32 udpSend(const char *data, qint32 size, const QHostAddress &addr, quint16 port) = 0;
+    virtual qint32 udpSend(const char *data, qint32 size, const HostAddress &addr, quint16 port) = 0;
 
     QByteArray makeDataPacket(const char *data, qint32 size);
     QByteArray makeShutdownPacket();
@@ -90,14 +90,14 @@ public:
     quint32 waterLine;
     quint32 connectionId;
 
-    QHostAddress remoteAddress;
+    HostAddress remoteAddress;
     quint16 remotePort;
 
     KcpSocket::Mode mode;
 };
 
 
-static inline QString concat(const QHostAddress &addr, quint16 port)
+static inline QString concat(const HostAddress &addr, quint16 port)
 {
     return addr.toString() + ":" + QString::number(port);
 }
@@ -106,7 +106,7 @@ static inline QString concat(const QHostAddress &addr, quint16 port)
 class MasterKcpSocketPrivate: public KcpSocketPrivate
 {
 public:
-    MasterKcpSocketPrivate(Socket::NetworkLayerProtocol protocol, KcpSocket *q);
+    MasterKcpSocketPrivate(HostAddress::NetworkLayerProtocol protocol, KcpSocket *q);
     MasterKcpSocketPrivate(qintptr socketDescriptor, KcpSocket *q);
     MasterKcpSocketPrivate(QSharedPointer<Socket> rawSocket, KcpSocket *q);
     virtual ~MasterKcpSocketPrivate() override;
@@ -114,16 +114,16 @@ public:
     virtual Socket::SocketError getError() const override;
     virtual QString getErrorString() const override;
     virtual bool isValid() const override;
-    virtual QHostAddress localAddress() const override;
+    virtual HostAddress localAddress() const override;
     virtual quint16 localPort() const override;
-    virtual Socket::NetworkLayerProtocol protocol() const override;
+    virtual HostAddress::NetworkLayerProtocol protocol() const override;
 public:
     virtual KcpSocket *accept() override;
-    virtual KcpSocket *accept(const QHostAddress &addr, quint16 port) override;
+    virtual KcpSocket *accept(const HostAddress &addr, quint16 port) override;
     virtual KcpSocket *accept(const QString &hostName, quint16 port, QSharedPointer<SocketDnsCache> dnsCache) override;
-    virtual bool bind(const QHostAddress &address, quint16 port, Socket::BindMode mode) override;
+    virtual bool bind(const HostAddress &address, quint16 port, Socket::BindMode mode) override;
     virtual bool bind(quint16 port, Socket::BindMode mode) override;
-    virtual bool connect(const QHostAddress &addr, quint16 port) override;
+    virtual bool connect(const HostAddress &addr, quint16 port) override;
     virtual bool connect(const QString &hostName, quint16 port, QSharedPointer<SocketDnsCache> dnsCache) override;
     virtual bool close(bool force) override;
     virtual bool listen(int backlog) override;
@@ -131,7 +131,7 @@ public:
     virtual QVariant option(Socket::SocketOption option) const override;
 public:
     virtual qint32 rawSend(const char *data, qint32 size) override;
-    virtual qint32 udpSend(const char *data, qint32 size, const QHostAddress &addr, quint16 port) override;
+    virtual qint32 udpSend(const char *data, qint32 size, const HostAddress &addr, quint16 port) override;
 public:
     void removeSlave(const QString &originalHostAndPort) { receiversByHostAndPort.remove(originalHostAndPort); }
     void removeSlave(quint32 connectionId) { receiversByConnectionId.remove(connectionId); }
@@ -139,7 +139,7 @@ public:
     void doReceive();
     void doAccept();
     bool startReceivingCoroutine();
-    QHostAddress resolve(const QString &hostName, QSharedPointer<SocketDnsCache> dnsCache);
+    HostAddress resolve(const QString &hostName, QSharedPointer<SocketDnsCache> dnsCache);
 public:
     QMap<QString, QPointer<class SlaveKcpSocketPrivate>> receiversByHostAndPort;
     QMap<quint32, QPointer<class SlaveKcpSocketPrivate>> receiversByConnectionId;
@@ -151,25 +151,25 @@ public:
 class SlaveKcpSocketPrivate: public KcpSocketPrivate
 {
 public:
-    SlaveKcpSocketPrivate(MasterKcpSocketPrivate *parent, const QHostAddress &addr, quint16 port, KcpSocket *q);
+    SlaveKcpSocketPrivate(MasterKcpSocketPrivate *parent, const HostAddress &addr, quint16 port, KcpSocket *q);
     virtual ~SlaveKcpSocketPrivate() override;
 public:
-    static KcpSocket *create(KcpSocketPrivate *d, const QHostAddress &addr, quint16 port, KcpSocket::Mode mode);
+    static KcpSocket *create(KcpSocketPrivate *d, const HostAddress &addr, quint16 port, KcpSocket::Mode mode);
     static SlaveKcpSocketPrivate *getPrivateHelper(KcpSocket *s);
 public:
     virtual Socket::SocketError getError() const override;
     virtual QString getErrorString() const override;
     virtual bool isValid() const override;
-    virtual QHostAddress localAddress() const override;
+    virtual HostAddress localAddress() const override;
     virtual quint16 localPort() const override;
-    virtual Socket::NetworkLayerProtocol protocol() const override;
+    virtual HostAddress::NetworkLayerProtocol protocol() const override;
 public:
     virtual KcpSocket *accept() override;
-    virtual KcpSocket *accept(const QHostAddress &addr, quint16 port) override;
+    virtual KcpSocket *accept(const HostAddress &addr, quint16 port) override;
     virtual KcpSocket *accept(const QString &hostName, quint16 port, QSharedPointer<SocketDnsCache> dnsCache) override;
-    virtual bool bind(const QHostAddress &address, quint16 port, Socket::BindMode mode) override;
+    virtual bool bind(const HostAddress &address, quint16 port, Socket::BindMode mode) override;
     virtual bool bind(quint16 port, Socket::BindMode mode) override;
-    virtual bool connect(const QHostAddress &addr, quint16 port) override;
+    virtual bool connect(const HostAddress &addr, quint16 port) override;
     virtual bool connect(const QString &hostName, quint16 port, QSharedPointer<SocketDnsCache> dnsCache) override;
     virtual bool close(bool force) override;
     virtual bool listen(int backlog) override;
@@ -177,14 +177,14 @@ public:
     virtual QVariant option(Socket::SocketOption option) const override;
 public:
     virtual qint32 rawSend(const char *data, qint32 size) override;
-    virtual qint32 udpSend(const char *data, qint32 size, const QHostAddress &addr, quint16 port) override;
+    virtual qint32 udpSend(const char *data, qint32 size, const HostAddress &addr, quint16 port) override;
 public:
     QString originalHostAndPort;
     QPointer<MasterKcpSocketPrivate> parent;
 };
 
 
-KcpSocket *SlaveKcpSocketPrivate::create(KcpSocketPrivate *d, const QHostAddress &addr, quint16 port, KcpSocket::Mode mode)
+KcpSocket *SlaveKcpSocketPrivate::create(KcpSocketPrivate *d, const HostAddress &addr, quint16 port, KcpSocket::Mode mode)
 {
     return new KcpSocket(d, addr, port, mode);
 }
@@ -261,7 +261,7 @@ KcpSocketPrivate::~KcpSocketPrivate()
 }
 
 
-QHostAddress KcpSocketPrivate::peerAddress() const
+HostAddress KcpSocketPrivate::peerAddress() const
 {
     return remoteAddress;
 }
@@ -602,7 +602,7 @@ QByteArray KcpSocketPrivate::makeMultiPathPacket(quint32 connectionId)
 }
 
 
-MasterKcpSocketPrivate::MasterKcpSocketPrivate(Socket::NetworkLayerProtocol protocol, KcpSocket *q)
+MasterKcpSocketPrivate::MasterKcpSocketPrivate(HostAddress::NetworkLayerProtocol protocol, KcpSocket *q)
     : KcpSocketPrivate(q), rawSocket(new Socket(protocol, Socket::UdpSocket))
 {
 }
@@ -652,7 +652,7 @@ bool MasterKcpSocketPrivate::isValid() const
 }
 
 
-QHostAddress MasterKcpSocketPrivate::localAddress() const
+HostAddress MasterKcpSocketPrivate::localAddress() const
 {
     return rawSocket->localAddress();
 }
@@ -664,7 +664,7 @@ quint16 MasterKcpSocketPrivate::localPort() const
 }
 
 
-Socket::NetworkLayerProtocol MasterKcpSocketPrivate::protocol() const
+HostAddress::NetworkLayerProtocol MasterKcpSocketPrivate::protocol() const
 {
     return rawSocket->protocol();
 }
@@ -749,7 +749,7 @@ quint32 MasterKcpSocketPrivate::nextConnectionId()
 void MasterKcpSocketPrivate::doReceive()
 {
     Q_Q(KcpSocket);
-    QHostAddress addr;
+    HostAddress addr;
     quint16 port;
     QByteArray buf(1024 * 64, Qt::Uninitialized);
     while (true) {
@@ -811,7 +811,7 @@ void MasterKcpSocketPrivate::doReceive()
 void MasterKcpSocketPrivate::doAccept()
 {
     Q_Q(KcpSocket);
-    QHostAddress addr;
+    HostAddress addr;
     quint16 port;
     QByteArray buf(1024 * 64, Qt::Uninitialized);
     while (true) {
@@ -936,7 +936,7 @@ KcpSocket *MasterKcpSocketPrivate::accept()
 }
 
 
-KcpSocket *MasterKcpSocketPrivate::accept(const QHostAddress &addr, quint16 port)
+KcpSocket *MasterKcpSocketPrivate::accept(const HostAddress &addr, quint16 port)
 {
     if (state != Socket::ListeningState || addr.isNull() || port == 0) {
         return nullptr;
@@ -965,7 +965,7 @@ KcpSocket *MasterKcpSocketPrivate::accept(const QString &hostName, quint16 port,
     if (state != Socket::ListeningState || hostName.isNull() || port == 0) {
         return nullptr;
     }
-    const QHostAddress &addr = resolve(hostName, dnsCache);
+    const HostAddress &addr = resolve(hostName, dnsCache);
     if (addr.isNull()) {
         return nullptr;
     } else {
@@ -974,7 +974,7 @@ KcpSocket *MasterKcpSocketPrivate::accept(const QString &hostName, quint16 port,
 }
 
 
-bool MasterKcpSocketPrivate::connect(const QHostAddress &addr, quint16 port)
+bool MasterKcpSocketPrivate::connect(const HostAddress &addr, quint16 port)
 {
     if ((state != Socket::UnconnectedState && state != Socket::BoundState) || addr.isNull()) {
         return false;
@@ -991,7 +991,7 @@ bool MasterKcpSocketPrivate::connect(const QString &hostName, quint16 port, QSha
     if (state != Socket::UnconnectedState && state != Socket::BoundState) {
         return false;
     }
-    const QHostAddress &addr = resolve(hostName, dnsCache);
+    const HostAddress &addr = resolve(hostName, dnsCache);
     if (addr.isNull()) {
         return false;
     } else {
@@ -1000,10 +1000,10 @@ bool MasterKcpSocketPrivate::connect(const QString &hostName, quint16 port, QSha
 }
 
 
-QHostAddress MasterKcpSocketPrivate::resolve(const QString &hostName, QSharedPointer<SocketDnsCache> dnsCache)
+HostAddress MasterKcpSocketPrivate::resolve(const QString &hostName, QSharedPointer<SocketDnsCache> dnsCache)
 {
-    QList<QHostAddress> addresses;
-    QHostAddress t;
+    QList<HostAddress> addresses;
+    HostAddress t;
     if (t.setAddress(hostName)) {
         addresses.append(t);
     } else {
@@ -1014,16 +1014,16 @@ QHostAddress MasterKcpSocketPrivate::resolve(const QString &hostName, QSharedPoi
         }
     }
     for (int i = 0; i < addresses.size(); ++i) {
-        const QHostAddress &addr = addresses.at(i);
-        if (rawSocket->protocol() == Socket::IPv4Protocol && addr.protocol() == QAbstractSocket::IPv6Protocol) {
+        const HostAddress &addr = addresses.at(i);
+        if (rawSocket->protocol() == HostAddress::IPv4Protocol && addr.protocol() == HostAddress::IPv6Protocol) {
             continue;
         }
-        if (rawSocket->protocol() == Socket::IPv6Protocol && addr.protocol() == QAbstractSocket::IPv4Protocol) {
+        if (rawSocket->protocol() == HostAddress::IPv6Protocol && addr.protocol() == HostAddress::IPv4Protocol) {
             continue;
         }
         return addr;
     }
-    return QHostAddress();
+    return HostAddress();
 }
 
 
@@ -1036,13 +1036,13 @@ qint32 MasterKcpSocketPrivate::rawSend(const char *data, qint32 size)
 }
 
 
-qint32 MasterKcpSocketPrivate::udpSend(const char *data, qint32 size, const QHostAddress &addr, quint16 port)
+qint32 MasterKcpSocketPrivate::udpSend(const char *data, qint32 size, const HostAddress &addr, quint16 port)
 {
     return rawSocket->sendto(data, size, addr, port);
 }
 
 
-bool MasterKcpSocketPrivate::bind(const QHostAddress &address, quint16 port, Socket::BindMode mode)
+bool MasterKcpSocketPrivate::bind(const HostAddress &address, quint16 port, Socket::BindMode mode)
 {
     if (state != Socket::UnconnectedState) {
         return false;
@@ -1088,7 +1088,7 @@ QVariant MasterKcpSocketPrivate::option(Socket::SocketOption option) const
 }
 
 
-SlaveKcpSocketPrivate::SlaveKcpSocketPrivate(MasterKcpSocketPrivate *parent, const QHostAddress &addr, quint16 port, KcpSocket *q)
+SlaveKcpSocketPrivate::SlaveKcpSocketPrivate(MasterKcpSocketPrivate *parent, const HostAddress &addr, quint16 port, KcpSocket *q)
     :KcpSocketPrivate(q), parent(parent)
 {
     remoteAddress = addr;
@@ -1137,10 +1137,10 @@ bool SlaveKcpSocketPrivate::isValid() const
 }
 
 
-QHostAddress SlaveKcpSocketPrivate::localAddress() const
+HostAddress SlaveKcpSocketPrivate::localAddress() const
 {
     if (parent.isNull()) {
-        return QHostAddress();
+        return HostAddress();
     }
     return parent->rawSocket->localAddress();
 }
@@ -1155,10 +1155,10 @@ quint16 SlaveKcpSocketPrivate::localPort() const
 }
 
 
-Socket::NetworkLayerProtocol SlaveKcpSocketPrivate::protocol() const
+HostAddress::NetworkLayerProtocol SlaveKcpSocketPrivate::protocol() const
 {
     if (parent.isNull()) {
-        return Socket::UnknownNetworkLayerProtocol;
+        return HostAddress::UnknownNetworkLayerProtocol;
     }
     return parent->rawSocket->protocol();
 }
@@ -1215,7 +1215,7 @@ KcpSocket *SlaveKcpSocketPrivate::accept()
 }
 
 
-KcpSocket *SlaveKcpSocketPrivate::accept(const QHostAddress &, quint16)
+KcpSocket *SlaveKcpSocketPrivate::accept(const HostAddress &, quint16)
 {
     return nullptr;
 }
@@ -1227,7 +1227,7 @@ KcpSocket *SlaveKcpSocketPrivate::accept(const QString &, quint16, QSharedPointe
 }
 
 
-bool SlaveKcpSocketPrivate::connect(const QHostAddress &, quint16)
+bool SlaveKcpSocketPrivate::connect(const HostAddress &, quint16)
 {
     return false;
 }
@@ -1251,7 +1251,7 @@ qint32 SlaveKcpSocketPrivate::rawSend(const char *data, qint32 size)
 }
 
 
-qint32 SlaveKcpSocketPrivate::udpSend(const char *data, qint32 size, const QHostAddress &addr, quint16 port)
+qint32 SlaveKcpSocketPrivate::udpSend(const char *data, qint32 size, const HostAddress &addr, quint16 port)
 {
     if (parent.isNull()) {
         return -1;
@@ -1261,7 +1261,7 @@ qint32 SlaveKcpSocketPrivate::udpSend(const char *data, qint32 size, const QHost
 }
 
 
-bool SlaveKcpSocketPrivate::bind(const QHostAddress &, quint16, Socket::BindMode)
+bool SlaveKcpSocketPrivate::bind(const HostAddress &, quint16, Socket::BindMode)
 {
     return false;
 }
@@ -1289,7 +1289,7 @@ QVariant SlaveKcpSocketPrivate::option(Socket::SocketOption option) const
 }
 
 
-KcpSocket::KcpSocket(Socket::NetworkLayerProtocol protocol)
+KcpSocket::KcpSocket(HostAddress::NetworkLayerProtocol protocol)
     : d_ptr(new MasterKcpSocketPrivate(protocol, this))
 {
     busy = d_ptr->busy;
@@ -1311,7 +1311,7 @@ KcpSocket::KcpSocket(QSharedPointer<Socket> rawSocket)
 }
 
 
-KcpSocket::KcpSocket(KcpSocketPrivate *parent, const QHostAddress &addr, const quint16 port, KcpSocket::Mode mode)
+KcpSocket::KcpSocket(KcpSocketPrivate *parent, const HostAddress &addr, const quint16 port, KcpSocket::Mode mode)
     :d_ptr(new SlaveKcpSocketPrivate(static_cast<MasterKcpSocketPrivate*>(parent), addr, port, this))
 {
     setMode(mode);
@@ -1396,7 +1396,7 @@ bool KcpSocket::isValid() const
 }
 
 
-QHostAddress KcpSocket::localAddress() const
+HostAddress KcpSocket::localAddress() const
 {
     Q_D(const KcpSocket);
     return d->localAddress();
@@ -1410,7 +1410,7 @@ quint16 KcpSocket::localPort() const
 }
 
 
-QHostAddress KcpSocket::peerAddress() const
+HostAddress KcpSocket::peerAddress() const
 {
     Q_D(const KcpSocket);
     return d->peerAddress();
@@ -1445,7 +1445,7 @@ Socket::SocketState KcpSocket::state() const
 }
 
 
-Socket::NetworkLayerProtocol KcpSocket::protocol() const
+HostAddress::NetworkLayerProtocol KcpSocket::protocol() const
 {
     Q_D(const KcpSocket);
     return d->protocol();
@@ -1459,7 +1459,7 @@ KcpSocket *KcpSocket::accept()
 }
 
 
-KcpSocket *KcpSocket::accept(const QHostAddress &addr, quint16 port)
+KcpSocket *KcpSocket::accept(const HostAddress &addr, quint16 port)
 {
     Q_D(KcpSocket);
     return d->accept(addr, port);
@@ -1473,7 +1473,7 @@ KcpSocket *KcpSocket::accept(const QString &hostName, quint16 port, QSharedPoint
 }
 
 
-bool KcpSocket::bind(const QHostAddress &address, quint16 port, Socket::BindMode mode)
+bool KcpSocket::bind(const HostAddress &address, quint16 port, Socket::BindMode mode)
 {
     Q_D(KcpSocket);
     return d->bind(address, port, mode);
@@ -1487,7 +1487,7 @@ bool KcpSocket::bind(quint16 port, Socket::BindMode mode)
 }
 
 
-bool KcpSocket::connect(const QHostAddress &addr, quint16 port)
+bool KcpSocket::connect(const HostAddress &addr, quint16 port)
 {
     Q_D(KcpSocket);
     return d->connect(addr, port);
@@ -1616,7 +1616,7 @@ qint32 KcpSocket::sendall(const QByteArray &data)
 }
 
 
-bool KcpSocket::filter(char *data, qint32 *len, QHostAddress *addr, quint16 *port)
+bool KcpSocket::filter(char *data, qint32 *len, HostAddress *addr, quint16 *port)
 {
     Q_UNUSED(data);
     Q_UNUSED(len);
@@ -1626,14 +1626,14 @@ bool KcpSocket::filter(char *data, qint32 *len, QHostAddress *addr, quint16 *por
 }
 
 
-qint32 KcpSocket::udpSend(const char *data, qint32 size, const QHostAddress &addr, quint16 port)
+qint32 KcpSocket::udpSend(const char *data, qint32 size, const HostAddress &addr, quint16 port)
 {
     Q_D(KcpSocket);
     return d->udpSend(data, size, addr, port);
 }
 
 
-KcpSocket *KcpSocket::createConnection(const QHostAddress &host, quint16 port, Socket::SocketError *error, int allowProtocol)
+KcpSocket *KcpSocket::createConnection(const HostAddress &host, quint16 port, Socket::SocketError *error, int allowProtocol)
 {
     return QTNETWORKNG_NAMESPACE::createConnection<KcpSocket>(host, port, error, allowProtocol, MakeSocketType<KcpSocket>);
 }
@@ -1646,7 +1646,7 @@ KcpSocket *KcpSocket::createConnection(const QString &hostName, quint16 port, So
 }
 
 
-KcpSocket *KcpSocket::createServer(const QHostAddress &host, quint16 port, int backlog)
+KcpSocket *KcpSocket::createServer(const HostAddress &host, quint16 port, int backlog)
 {
     return QTNETWORKNG_NAMESPACE::createServer<KcpSocket>(host, port, backlog, MakeSocketType<KcpSocket>);
 }
@@ -1663,21 +1663,21 @@ public:
     virtual Socket::SocketError error() const override;
     virtual QString errorString() const override;
     virtual bool isValid() const override;
-    virtual QHostAddress localAddress() const override;
+    virtual HostAddress localAddress() const override;
     virtual quint16 localPort() const override;
-    virtual QHostAddress peerAddress() const override;
+    virtual HostAddress peerAddress() const override;
     virtual QString peerName() const override;
     virtual quint16 peerPort() const override;
     virtual qintptr	fileno() const override;
     virtual Socket::SocketType type() const override;
     virtual Socket::SocketState state() const override;
-    virtual Socket::NetworkLayerProtocol protocol() const override;
+    virtual HostAddress::NetworkLayerProtocol protocol() const override;
 
     virtual Socket *acceptRaw() override;
     virtual QSharedPointer<SocketLike> accept() override;
-    virtual bool bind(const QHostAddress &address, quint16 port, Socket::BindMode mode) override;
+    virtual bool bind(const HostAddress &address, quint16 port, Socket::BindMode mode) override;
     virtual bool bind(quint16 port, Socket::BindMode mode) override;
-    virtual bool connect(const QHostAddress &addr, quint16 port) override;
+    virtual bool connect(const HostAddress &addr, quint16 port) override;
     virtual bool connect(const QString &hostName, quint16 port, QSharedPointer<SocketDnsCache> dnsCache) override;
     virtual void close() override;
     virtual void abort() override;
@@ -1720,7 +1720,7 @@ bool SocketLikeImpl::isValid() const
 }
 
 
-QHostAddress SocketLikeImpl::localAddress() const
+HostAddress SocketLikeImpl::localAddress() const
 {
     return s->localAddress();
 }
@@ -1732,7 +1732,7 @@ quint16 SocketLikeImpl::localPort() const
 }
 
 
-QHostAddress SocketLikeImpl::peerAddress() const
+HostAddress SocketLikeImpl::peerAddress() const
 {
     return s->peerAddress();
 }
@@ -1768,7 +1768,7 @@ Socket::SocketState SocketLikeImpl::state() const
 }
 
 
-Socket::NetworkLayerProtocol SocketLikeImpl::protocol() const
+HostAddress::NetworkLayerProtocol SocketLikeImpl::protocol() const
 {
     return s->protocol();
 }
@@ -1786,7 +1786,7 @@ QSharedPointer<SocketLike> SocketLikeImpl::accept()
 }
 
 
-bool SocketLikeImpl::bind(const QHostAddress &address, quint16 port = 0, Socket::BindMode mode = Socket::DefaultForPlatform)
+bool SocketLikeImpl::bind(const HostAddress &address, quint16 port = 0, Socket::BindMode mode = Socket::DefaultForPlatform)
 {
     return s->bind(address, port, mode);
 }
@@ -1798,7 +1798,7 @@ bool SocketLikeImpl::bind(quint16 port, Socket::BindMode mode)
 }
 
 
-bool SocketLikeImpl::connect(const QHostAddress &addr, quint16 port)
+bool SocketLikeImpl::connect(const HostAddress &addr, quint16 port)
 {
     return s->connect(addr, port);
 }

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -22,7 +22,7 @@ QByteArray randomBytes(int numBytes)
 {
     QByteArray b;
     b.reserve(numBytes);
-    QRandomGenerator *generator = QRandomGenerator->global();
+    QRandomGenerator *generator = QRandomGenerator::global();
     for (int i = 0; i < numBytes; ++i) {
         b.append(static_cast<char>(generator->bounded(0xff)));
     }

--- a/src/socket_server.cpp
+++ b/src/socket_server.cpp
@@ -12,7 +12,7 @@ QTNETWORKNG_NAMESPACE_BEGIN
 class BaseStreamServerPrivate
 {
 public:
-    BaseStreamServerPrivate(BaseStreamServer *q, const QHostAddress &serverAddress, quint16 serverPort)
+    BaseStreamServerPrivate(BaseStreamServer *q, const HostAddress &serverAddress, quint16 serverPort)
         : operations(new CoroutineGroup)
         , serverAddress(serverAddress)
         , userData(nullptr)
@@ -26,7 +26,7 @@ public:
 public:
     QSharedPointer<SocketLike> serverSocket;
     CoroutineGroup *operations;
-    QHostAddress serverAddress;
+    HostAddress serverAddress;
     void *userData;
     int requestQueueSize;
     quint16 serverPort;
@@ -37,7 +37,7 @@ private:
 };
 
 
-BaseStreamServer::BaseStreamServer(const QHostAddress &serverAddress, quint16 serverPort)
+BaseStreamServer::BaseStreamServer(const HostAddress &serverAddress, quint16 serverPort)
     : started(new Event())
     , stopped(new Event())
     , d_ptr(new BaseStreamServerPrivate(this, serverAddress, serverPort))
@@ -255,7 +255,7 @@ quint16 BaseStreamServer::serverPort() const
 }
 
 
-QHostAddress BaseStreamServer::serverAddress() const
+HostAddress BaseStreamServer::serverAddress() const
 {
     Q_D(const BaseStreamServer);
     return d->serverAddress;

--- a/src/socket_utils.cpp
+++ b/src/socket_utils.cpp
@@ -36,21 +36,21 @@ public:
     virtual Socket::SocketError error() const override;
     virtual QString errorString() const override;
     virtual bool isValid() const override;
-    virtual QHostAddress localAddress() const override;
+    virtual HostAddress localAddress() const override;
     virtual quint16 localPort() const override;
-    virtual QHostAddress peerAddress() const override;
+    virtual HostAddress peerAddress() const override;
     virtual QString peerName() const override;
     virtual quint16 peerPort() const override;
     virtual qintptr	fileno() const override;
     virtual Socket::SocketType type() const override;
     virtual Socket::SocketState state() const override;
-    virtual Socket::NetworkLayerProtocol protocol() const override;
+    virtual HostAddress::NetworkLayerProtocol protocol() const override;
 
     virtual Socket *acceptRaw() override;
     virtual QSharedPointer<SocketLike> accept() override;
-    virtual bool bind(const QHostAddress &address, quint16 port, Socket::BindMode mode) override;
+    virtual bool bind(const HostAddress &address, quint16 port, Socket::BindMode mode) override;
     virtual bool bind(quint16 port, Socket::BindMode mode) override;
-    virtual bool connect(const QHostAddress &addr, quint16 port) override;
+    virtual bool connect(const HostAddress &addr, quint16 port) override;
     virtual bool connect(const QString &hostName, quint16 port, QSharedPointer<SocketDnsCache> dnsCache = QSharedPointer<SocketDnsCache>()) override;
     virtual void close() override;
     virtual void abort() override;
@@ -94,7 +94,7 @@ bool SocketLikeImpl::isValid() const
 }
 
 
-QHostAddress SocketLikeImpl::localAddress() const
+HostAddress SocketLikeImpl::localAddress() const
 {
     return s->localAddress();
 }
@@ -106,7 +106,7 @@ quint16 SocketLikeImpl::localPort() const
 }
 
 
-QHostAddress SocketLikeImpl::peerAddress() const
+HostAddress SocketLikeImpl::peerAddress() const
 {
     return s->peerAddress();
 }
@@ -142,7 +142,7 @@ Socket::SocketState SocketLikeImpl::state() const
 }
 
 
-Socket::NetworkLayerProtocol SocketLikeImpl::protocol() const
+HostAddress::NetworkLayerProtocol SocketLikeImpl::protocol() const
 {
     return s->protocol();
 }
@@ -165,7 +165,7 @@ QSharedPointer<SocketLike> SocketLikeImpl::accept()
 }
 
 
-bool SocketLikeImpl::bind(const QHostAddress &address, quint16 port, Socket::BindMode mode)
+bool SocketLikeImpl::bind(const HostAddress &address, quint16 port, Socket::BindMode mode)
 {
     return s->bind(address, port, mode);
 }
@@ -177,7 +177,7 @@ bool SocketLikeImpl::bind(quint16 port, Socket::BindMode mode)
 }
 
 
-bool SocketLikeImpl::connect(const QHostAddress &addr, quint16 port)
+bool SocketLikeImpl::connect(const HostAddress &addr, quint16 port)
 {
     return s->connect(addr, port);
 }

--- a/src/ssl.cpp
+++ b/src/ssl.cpp
@@ -1284,7 +1284,7 @@ bool SslSocketPrivate::isValid() const
 }
 
 
-SslSocket::SslSocket(Socket::NetworkLayerProtocol protocol, const SslConfiguration &config)
+SslSocket::SslSocket(HostAddress::NetworkLayerProtocol protocol, const SslConfiguration &config)
     :d_ptr(new SslSocketPrivate(config))
 {
     Q_D(SslSocket);
@@ -1449,7 +1449,7 @@ Socket *SslSocket::acceptRaw()
 }
 
 
-bool SslSocket::bind(const QHostAddress &address, quint16 port, Socket::BindMode mode)
+bool SslSocket::bind(const HostAddress &address, quint16 port, Socket::BindMode mode)
 {
     Q_D(SslSocket);
     return d->rawSocket->bind(address, port, mode);
@@ -1463,7 +1463,7 @@ bool SslSocket::bind(quint16 port, Socket::BindMode mode)
 }
 
 
-bool SslSocket::connect(const QHostAddress &addr, quint16 port)
+bool SslSocket::connect(const HostAddress &addr, quint16 port)
 {
     Q_D(SslSocket);
     if (!d->rawSocket->connect(addr, port)) {
@@ -1546,7 +1546,7 @@ bool SslSocket::isValid() const
 }
 
 
-QHostAddress SslSocket::localAddress() const
+HostAddress SslSocket::localAddress() const
 {
     Q_D(const SslSocket);
     return d->rawSocket->localAddress();
@@ -1560,7 +1560,7 @@ quint16 SslSocket::localPort() const
 }
 
 
-QHostAddress SslSocket::peerAddress() const
+HostAddress SslSocket::peerAddress() const
 {
     Q_D(const SslSocket);
     return d->rawSocket->peerAddress();
@@ -1602,7 +1602,7 @@ Socket::SocketState SslSocket::state() const
 }
 
 
-Socket::NetworkLayerProtocol SslSocket::protocol() const
+HostAddress::NetworkLayerProtocol SslSocket::protocol() const
 {
     Q_D(const SslSocket);
     return d->rawSocket->protocol();
@@ -1686,10 +1686,10 @@ qint32 SslSocket::sendall(const QByteArray &data)
 }
 
 
-SslSocket *SslSocket::createConnection(const QHostAddress &host, quint16 port,
+SslSocket *SslSocket::createConnection(const HostAddress &host, quint16 port,
               const SslConfiguration &config, Socket::SocketError *error, int allowProtocol)
 {
-    std::function<SslSocket*(Socket::NetworkLayerProtocol)> func = [config] (Socket::NetworkLayerProtocol protocol) -> SslSocket * {
+    std::function<SslSocket*(HostAddress::NetworkLayerProtocol)> func = [config] (HostAddress::NetworkLayerProtocol protocol) -> SslSocket * {
         return new SslSocket(protocol, config);
     };
     return QTNETWORKNG_NAMESPACE::createConnection<SslSocket>(host, port, error, allowProtocol, func);
@@ -1700,17 +1700,17 @@ SslSocket *SslSocket::createConnection(const QString &hostName, quint16 port,
               const SslConfiguration &config, Socket::SocketError *error,
               QSharedPointer<SocketDnsCache> dnsCache, int allowProtocol)
 {
-    std::function<SslSocket*(Socket::NetworkLayerProtocol)> func = [config] (Socket::NetworkLayerProtocol protocol) -> SslSocket * {
+    std::function<SslSocket*(HostAddress::NetworkLayerProtocol)> func = [config] (HostAddress::NetworkLayerProtocol protocol) -> SslSocket * {
         return new SslSocket(protocol, config);
     };
     return QTNETWORKNG_NAMESPACE::createConnection<SslSocket>(hostName, port, error, dnsCache, allowProtocol, func);
 }
 
 
-SslSocket *SslSocket::createServer(const QHostAddress &host, quint16 port,
+SslSocket *SslSocket::createServer(const HostAddress &host, quint16 port,
                                                   const SslConfiguration &config, int backlog)
 {
-    std::function<SslSocket*(Socket::NetworkLayerProtocol)> func = [config] (Socket::NetworkLayerProtocol protocol) -> SslSocket * {
+    std::function<SslSocket*(HostAddress::NetworkLayerProtocol)> func = [config] (HostAddress::NetworkLayerProtocol protocol) -> SslSocket * {
         return new SslSocket(protocol, config);
     };
     return QTNETWORKNG_NAMESPACE::createServer<SslSocket>(host, port, backlog, func);
@@ -1727,21 +1727,21 @@ public:
     virtual Socket::SocketError error() const override;
     virtual QString errorString() const override;
     virtual bool isValid() const override;
-    virtual QHostAddress localAddress() const override;
+    virtual HostAddress localAddress() const override;
     virtual quint16 localPort() const override;
-    virtual QHostAddress peerAddress() const override;
+    virtual HostAddress peerAddress() const override;
     virtual QString peerName() const override;
     virtual quint16 peerPort() const override;
     virtual qintptr	fileno() const override;
     virtual Socket::SocketType type() const override;
     virtual Socket::SocketState state() const override;
-    virtual Socket::NetworkLayerProtocol protocol() const override;
+    virtual HostAddress::NetworkLayerProtocol protocol() const override;
 
     virtual Socket *acceptRaw() override;
     virtual QSharedPointer<SocketLike> accept() override;
-    virtual bool bind(const QHostAddress &address, quint16 port, Socket::BindMode mode) override;
+    virtual bool bind(const HostAddress &address, quint16 port, Socket::BindMode mode) override;
     virtual bool bind(quint16 port, Socket::BindMode mode) override;
-    virtual bool connect(const QHostAddress &addr, quint16 port) override;
+    virtual bool connect(const HostAddress &addr, quint16 port) override;
     virtual bool connect(const QString &hostName, quint16 port, QSharedPointer<SocketDnsCache> dnsCache) override;
     virtual void close() override;
     virtual void abort() override;
@@ -1784,7 +1784,7 @@ bool SocketLikeImpl::isValid() const
 }
 
 
-QHostAddress SocketLikeImpl::localAddress() const
+HostAddress SocketLikeImpl::localAddress() const
 {
     return s->localAddress();
 }
@@ -1796,7 +1796,7 @@ quint16 SocketLikeImpl::localPort() const
 }
 
 
-QHostAddress SocketLikeImpl::peerAddress() const
+HostAddress SocketLikeImpl::peerAddress() const
 {
     return s->peerAddress();
 }
@@ -1832,7 +1832,7 @@ Socket::SocketState SocketLikeImpl::state() const
 }
 
 
-Socket::NetworkLayerProtocol SocketLikeImpl::protocol() const
+HostAddress::NetworkLayerProtocol SocketLikeImpl::protocol() const
 {
     return s->protocol();
 }
@@ -1850,7 +1850,7 @@ QSharedPointer<SocketLike> SocketLikeImpl::accept()
 }
 
 
-bool SocketLikeImpl::bind(const QHostAddress &address, quint16 port = 0, Socket::BindMode mode = Socket::DefaultForPlatform)
+bool SocketLikeImpl::bind(const HostAddress &address, quint16 port = 0, Socket::BindMode mode = Socket::DefaultForPlatform)
 {
     return s->bind(address, port, mode);
 }
@@ -1862,7 +1862,7 @@ bool SocketLikeImpl::bind(quint16 port, Socket::BindMode mode)
 }
 
 
-bool SocketLikeImpl::connect(const QHostAddress &addr, quint16 port)
+bool SocketLikeImpl::connect(const HostAddress &addr, quint16 port)
 {
     return s->connect(addr, port);
 }
@@ -1983,21 +1983,21 @@ public:
     virtual Socket::SocketError error() const override;
     virtual QString errorString() const override;
     virtual bool isValid() const override;
-    virtual QHostAddress localAddress() const override;
+    virtual HostAddress localAddress() const override;
     virtual quint16 localPort() const override;
-    virtual QHostAddress peerAddress() const override;
+    virtual HostAddress peerAddress() const override;
     virtual QString peerName() const override;
     virtual quint16 peerPort() const override;
     virtual qintptr	fileno() const override;
     virtual Socket::SocketType type() const override;
     virtual Socket::SocketState state() const override;
-    virtual Socket::NetworkLayerProtocol protocol() const override;
+    virtual HostAddress::NetworkLayerProtocol protocol() const override;
 
     virtual Socket *acceptRaw() override;
     virtual QSharedPointer<SocketLike> accept() override;
-    virtual bool bind(const QHostAddress &address, quint16 port, Socket::BindMode mode) override;
+    virtual bool bind(const HostAddress &address, quint16 port, Socket::BindMode mode) override;
     virtual bool bind(quint16 port, Socket::BindMode mode) override;
-    virtual bool connect(const QHostAddress &addr, quint16 port) override;
+    virtual bool connect(const HostAddress &addr, quint16 port) override;
     virtual bool connect(const QString &hostName, quint16 port, QSharedPointer<SocketDnsCache> dnsCache) override;
     virtual void close() override;
     virtual void abort() override;
@@ -2054,7 +2054,7 @@ bool EncryptedSocketLike::isValid() const
 }
 
 
-QHostAddress EncryptedSocketLike::localAddress() const
+HostAddress EncryptedSocketLike::localAddress() const
 {
     return s->localAddress();
 }
@@ -2066,7 +2066,7 @@ quint16 EncryptedSocketLike::localPort() const
 }
 
 
-QHostAddress EncryptedSocketLike::peerAddress() const
+HostAddress EncryptedSocketLike::peerAddress() const
 {
     return s->peerAddress();
 }
@@ -2102,7 +2102,7 @@ Socket::SocketState EncryptedSocketLike::state() const
 }
 
 
-Socket::NetworkLayerProtocol EncryptedSocketLike::protocol() const
+HostAddress::NetworkLayerProtocol EncryptedSocketLike::protocol() const
 {
     return s->protocol();
 }
@@ -2120,7 +2120,7 @@ QSharedPointer<SocketLike> EncryptedSocketLike::accept()
 }
 
 
-bool EncryptedSocketLike::bind(const QHostAddress &address, quint16 port = 0, Socket::BindMode mode = Socket::DefaultForPlatform)
+bool EncryptedSocketLike::bind(const HostAddress &address, quint16 port = 0, Socket::BindMode mode = Socket::DefaultForPlatform)
 {
     return s->bind(address, port, mode);
 }
@@ -2132,7 +2132,7 @@ bool EncryptedSocketLike::bind(quint16 port, Socket::BindMode mode)
 }
 
 
-bool EncryptedSocketLike::connect(const QHostAddress &addr, quint16 port)
+bool EncryptedSocketLike::connect(const HostAddress &addr, quint16 port)
 {
     return s->connect(addr, port);
 }

--- a/tests/simple_httpd.cpp
+++ b/tests/simple_httpd.cpp
@@ -6,7 +6,7 @@ using namespace qtng;
 int main(int argc, char **argv)
 {
     QCoreApplication app(argc, argv);
-    SimpleHttpServer httpd(QHostAddress(QHostAddress::Any), 8000);
+    SimpleHttpServer httpd(HostAddress(HostAddress::Any), 8000);
     httpd.serveForever();
     return 0;
 }

--- a/tests/test_data_channel.cpp
+++ b/tests/test_data_channel.cpp
@@ -57,7 +57,7 @@ public:
     virtual void run()
     {
         QSharedPointer<qtng::Socket> client = QSharedPointer<qtng::Socket>::create();
-//        bool success = client->connect(QHostAddress::LocalHost, 7923);
+//        bool success = client->connect(HostAddress::LocalHost, 7923);
         bool success = client->connect("127.0.0.1", 7923);
         if(!success) {
             return;

--- a/tests/test_ssl.cpp
+++ b/tests/test_ssl.cpp
@@ -76,7 +76,7 @@ void TestSsl::testServer()
     QVERIFY(port != 0);
     QSharedPointer<Coroutine> clientCoroutine(Coroutine::spawn([port]{
         SslSocket client;
-        bool success = client.connect(QHostAddress::LocalHost, port);
+        bool success = client.connect(HostAddress::LocalHost, port);
         if (!success) {
             return;
         }


### PR DESCRIPTION

    1 remove QHostAddress. note: HostAddress has construct function to support QHostAddress when app depends on QtNetwork
    2 fix mac socket error