### PR TITLE
1、localPort uninitialize caused that when use udp socket, we can't kn…

### DIFF
--- a/src/kcp.cpp
+++ b/src/kcp.cpp
@@ -298,7 +298,7 @@ void KcpSocketPrivate::setMode(KcpSocket::Mode mode)
         ikcp_setmtu(kcp, 1400);
         ikcp_wndsize(kcp, 1024, 1024);
         kcp->rx_minrto = 30;
-        kcp->interval = 5;
+        //kcp->interval = 5;
         break;
     case KcpSocket::FastInternet:
         waterLine = 192;
@@ -306,23 +306,23 @@ void KcpSocketPrivate::setMode(KcpSocket::Mode mode)
         ikcp_setmtu(kcp, 1400);
         ikcp_wndsize(kcp, 512, 512);
         kcp->rx_minrto = 20;
-        kcp->interval = 2;
+        //kcp->interval = 2;
         break;
     case KcpSocket::Ethernet:
         waterLine = 64;
-        ikcp_nodelay(kcp, 1, 1, 4, 0);
+        ikcp_nodelay(kcp, 1, 10, 4, 0);
         ikcp_setmtu(kcp, 1024 * 32);
         ikcp_wndsize(kcp, 128, 128);
         kcp->rx_minrto = 10;
-        kcp->interval = 1;
+        //kcp->interval = 1;
         break;
     case KcpSocket::Loopback:
         waterLine = 64;
-        ikcp_nodelay(kcp, 1, 1, 0, 0);
+        ikcp_nodelay(kcp, 1, 10, 0, 0);
         ikcp_setmtu(kcp, 1024 * 64 - 256);
         ikcp_wndsize(kcp, 128, 128);
         kcp->rx_minrto = 5;
-        kcp->interval = 1;
+        //kcp->interval = 1;
         break;
     }
 }

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -17,6 +17,8 @@ SocketPrivate::SocketPrivate(HostAddress::NetworkLayerProtocol protocol, Socket:
     , type(type)
     , error(Socket::NoError)
     , state(Socket::UnconnectedState)
+    , localPort(0)
+    , peerPort(0)
 {
 #ifdef Q_OS_WIN
     initWinSock();

--- a/src/socket_win.cpp
+++ b/src/socket_win.cpp
@@ -537,6 +537,10 @@ bool SocketPrivate::bind(const HostAddress &a, quint16 port, Socket::BindMode mo
            address.toString().toLatin1().constData(), port);
 #endif
     state = Socket::BoundState;
+
+    if (port == 0) {
+        fetchConnectionParameters();
+    }
     return true;
 }
 


### PR DESCRIPTION
…ow real localPort

2、fix that unknown localPort when bind port == 0
3、fix kcp use too many cpu