### PR TITLE
prevent cpu 100% in QtEventLoop mode

### DIFF
--- a/include/private/eventloop_p.h
+++ b/include/private/eventloop_p.h
@@ -9,20 +9,20 @@ class Functor
 {
 public:
     virtual ~Functor();
-    virtual void operator()() = 0;
+    virtual bool operator()() = 0;
 };
 
 class DoNothingFunctor : public Functor
 {
 public:
-    virtual void operator()();
+    virtual bool operator()();
 };
 
 class YieldCurrentFunctor : public Functor
 {
 public:
     explicit YieldCurrentFunctor();
-    virtual void operator()();
+    virtual bool operator()();
     QPointer<BaseCoroutine> coroutine;
 };
 
@@ -34,7 +34,7 @@ public:
         : p(p)
     {
     }
-    virtual void operator()() { delete p; }
+    virtual bool operator()() { delete p; return true; }
     T * const p;
 };
 
@@ -45,7 +45,7 @@ public:
         : callback(callback)
     {
     }
-    virtual void operator()() override;
+    virtual bool operator()() override;
     std::function<void()> callback;
 };
 

--- a/src/coroutine_utils.cpp
+++ b/src/coroutine_utils.cpp
@@ -13,9 +13,10 @@ QTNG_LOGGER("qtng.coroutine");
 
 QTNETWORKNG_NAMESPACE_BEGIN
 
-void LambdaFunctor::operator()()
+bool LambdaFunctor::operator()()
 {
     callback();
+    return true;
 }
 
 class MarkDoneFunctor : public Functor
@@ -25,13 +26,14 @@ public:
         : done(done)
     {
     }
-    virtual void operator()() override;
+    virtual bool operator()() override;
     QSharedPointer<Event> done;
 };
 
-void MarkDoneFunctor::operator()()
+bool MarkDoneFunctor::operator()()
 {
     done->set();
+    return true;
 }
 
 DeferCallThread::DeferCallThread(std::function<void()> makeResult, QSharedPointer<Event> done,
@@ -350,11 +352,14 @@ class DeleteCoroutineFunctor : public Functor
 {
 public:
     virtual ~DeleteCoroutineFunctor() override;
-    virtual void operator()() override;
+    virtual bool operator()() override;
     QSharedPointer<BaseCoroutine> coroutine;
 };
 DeleteCoroutineFunctor::~DeleteCoroutineFunctor() { }
-void DeleteCoroutineFunctor::operator()() { }
+bool DeleteCoroutineFunctor::operator()()
+{
+    return true;
+}
 
 void CoroutineGroup::deleteCoroutine(BaseCoroutine *baseCoroutine)
 {

--- a/src/eventloop_ev.cpp
+++ b/src/eventloop_ev.cpp
@@ -243,12 +243,13 @@ struct TriggerIoWatchersFunctor : public Functor
     }
     EvEventLoopCoroutinePrivate *eventloop;
     int watcherId;
-    virtual void operator()() override
+    virtual bool operator()() override
     {
         IoWatcher *watcher = dynamic_cast<IoWatcher *>(eventloop->watchers.value(watcherId));
         if (watcher) {
-            (*watcher->callback)();
+            return (*watcher->callback)();
         }
+        return false;
     }
 };
 

--- a/src/eventloop_win.cpp
+++ b/src/eventloop_win.cpp
@@ -316,13 +316,14 @@ struct TriggerIoWatchersFunctor: public Functor
     virtual ~TriggerIoWatchersFunctor() override;
     WinEventLoopCoroutinePrivate *eventloop;
     int watcherId;
-    virtual void operator()() override
+    virtual bool operator()() override
     {
         IoWatcher *watcher = dynamic_cast<IoWatcher*>(eventloop->watchers.take(watcherId));
         if (watcher) {
             (*watcher->callback)();
             delete watcher;
         }
+        return true;
     }
 };
 

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -1154,6 +1154,12 @@ HttpResponse HttpSessionPrivate::send(HttpRequest &request)
                 response.setError(new ConnectionError());
                 return response;
             }
+        } catch (...) {
+            if (sendingReuqestBodyCoroutine->isRunning()) {
+                sendingReuqestBodyCoroutine->kill();
+            }
+            sendingReuqestBodyCoroutine->join();
+            throw;
         }
     }
 

--- a/src/locks.cpp
+++ b/src/locks.cpp
@@ -112,7 +112,7 @@ public:
     }
     QSharedPointer<SemaphorePrivate> sp;
     bool doDelete;
-    virtual void operator()() override
+    virtual bool operator()() override
     {
         while ((doDelete || (sp->notified != 0 && sp->counter > 0)) && !sp->waiters.isEmpty()) {
             QPointer<BaseCoroutine> waiter = sp->waiters.takeFirst();
@@ -124,6 +124,7 @@ public:
         }
         // do not move this line above the loop, see the Q_ASSERT_X(notified != 0) in SemaphorePrivate::acquire()
         sp->notified = 0;
+        return true;
     }
 };
 
@@ -584,7 +585,11 @@ public:
         : condition(condition)
     {
     }
-    virtual void operator()() { condition->notifyAll(); }
+    virtual bool operator()()
+    {
+        condition->notifyAll();
+        return true;
+    }
     QSharedPointer<Condition> condition;
 };
 

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -676,7 +676,7 @@ class PollFunctor : public Functor
 public:
     PollFunctor(QSharedPointer<QSet<QSharedPointer<Socket>>> events, QSharedPointer<Event> done,
                 QSharedPointer<Socket> socket);
-    virtual void operator()();
+    virtual bool operator()();
     QSharedPointer<QSet<QSharedPointer<Socket>>> events;
     QSharedPointer<Event> done;
     QWeakPointer<Socket> socket;
@@ -690,12 +690,13 @@ PollFunctor::PollFunctor(QSharedPointer<QSet<QSharedPointer<Socket>>> events, QS
 {
 }
 
-void PollFunctor::operator()()
+bool PollFunctor::operator()()
 {
     if (!socket.isNull()) {
         events->insert(socket.toStrongRef());
         done->set();
     }
+    return true;
 }
 
 PollPrivate::PollPrivate()


### PR DESCRIPTION
1、prevent cpu 100% in QtEventLoop mode
2、fix memory leak if send http body timeout