### PR TITLE
Fix spawnWithName(replace=true) joining the old coroutine on the caller.

### DIFF
--- a/include/coroutine_utils.h
+++ b/include/coroutine_utils.h
@@ -356,16 +356,20 @@ QSharedPointer<Coroutine> CoroutineGroup::spawnWithName(const QString &name, con
                                                         bool replace)
 {
     QSharedPointer<Coroutine> old = get(name);
+    QSharedPointer<Coroutine> coroutine;
     if (!old.isNull()) {
-        if (replace) {
-            old->kill();
-            coroutines.remove(old);
-            old->join();
-        } else {
+        if (!replace) {
             return old;
         }
+        old->kill();
+        coroutines.remove(old);
+        coroutine = QSharedPointer<Coroutine>(Coroutine::spawn([old, func] {
+            old->join();
+            func();
+        }));
+    } else {
+        coroutine = QSharedPointer<Coroutine>(Coroutine::spawn(func));
     }
-    QSharedPointer<Coroutine> coroutine(Coroutine::spawn(func));
     add(coroutine, name);
     return coroutine;
 }

--- a/src/eventloop_ev.cpp
+++ b/src/eventloop_ev.cpp
@@ -357,7 +357,11 @@ bool EvEventLoopCoroutinePrivate::runUntil(BaseCoroutine *coroutine)
             }
         };
         int callbackId = coroutine->finished.addCallback(here);
-        loopCoroutine->yield();
+        if (!loopCoroutine->yield()) {
+            qtng_warning << "runUntil: yield to loop coroutine failed.";
+            coroutine->finished.remove(callbackId);
+            return false;
+        }
         coroutine->finished.remove(callbackId);
     } else {
         QPointer<BaseCoroutine> old = loopCoroutine;

--- a/src/eventloop_qt.cpp
+++ b/src/eventloop_qt.cpp
@@ -347,7 +347,11 @@ bool QtEventLoopCoroutinePrivate::runUntil(BaseCoroutine *coroutine)
             }
         };
         int callbackId = coroutine->finished.addCallback(return_here);
-        loopCoroutine->yield();
+        if (!loopCoroutine->yield()) {
+            qtng_warning << "runUntil: yield to loop coroutine failed.";
+            coroutine->finished.remove(callbackId);
+            return false;
+        }
         coroutine->finished.remove(callbackId);
     } else {
         QPointer<BaseCoroutine> old = loopCoroutine;

--- a/src/eventloop_win.cpp
+++ b/src/eventloop_win.cpp
@@ -11,7 +11,10 @@
 #include <stddef.h>
 #include <windows.h>
 #include "../include/private/eventloop_p.h"
+#include "debugger.h"
 #include <queue>
+
+QTNG_LOGGER("qtng.eventloop_win");
 
 QTNETWORKNG_NAMESPACE_BEGIN
 
@@ -419,7 +422,11 @@ bool WinEventLoopCoroutinePrivate::runUntil(BaseCoroutine *coroutine)
             }
         };
         int callbackId = coroutine->finished.addCallback(here);
-        loopCoroutine->yield();
+        if (!loopCoroutine->yield()) {
+            qtng_warning << "runUntil: yield to loop coroutine failed.";
+            coroutine->finished.remove(callbackId);
+            return false;
+        }
         coroutine->finished.remove(callbackId);
     } else {
         QPointer<BaseCoroutine> old = loopCoroutine;

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -805,7 +805,8 @@ QSharedPointer<SocketLike> ConnectionPool::oldConnectionForUrl(const QUrl &url)
 
         char tbuf;
         // should i use `peek()`?
-        if (connection->peekRaw(&tbuf, 1) >= 0) {
+        if (connection->peekRaw(&tbuf, 1) == 0) {
+            // we want a "clean" connection. result > 0 means not clean. may it's close notify by ssl connection.
             // qtng_debug << "reuse connect" << connection->localPort();
             return connection;
             //} else {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,3 +45,7 @@ add_test(qtng_tests test_pipe)
 add_executable(test_coroutine_group_spawn_with_name test_coroutine_group_spawn_with_name.cpp)
 target_link_libraries(test_coroutine_group_spawn_with_name PRIVATE Qt5::Core Qt5::Test qtnetworkng)
 add_test(test_coroutine_group_spawn_with_name test_coroutine_group_spawn_with_name)
+
+add_executable(test_https_keepalive test_https_keepalive.cpp)
+target_link_libraries(test_https_keepalive PRIVATE Qt5::Core Qt5::Test qtnetworkng)
+add_test(test_https_keepalive test_https_keepalive)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -41,3 +41,7 @@ add_test(qtng_tests test_lmdb)
 add_executable(test_pipe test_pipe.cpp)
 target_link_libraries(test_pipe PRIVATE Qt5::Core Qt5::Test qtnetworkng)
 add_test(qtng_tests test_pipe)
+
+add_executable(test_coroutine_group_spawn_with_name test_coroutine_group_spawn_with_name.cpp)
+target_link_libraries(test_coroutine_group_spawn_with_name PRIVATE Qt5::Core Qt5::Test qtnetworkng)
+add_test(test_coroutine_group_spawn_with_name test_coroutine_group_spawn_with_name)

--- a/tests/test_coroutine_group_spawn_with_name.cpp
+++ b/tests/test_coroutine_group_spawn_with_name.cpp
@@ -1,0 +1,155 @@
+#include <QtTest>
+#include "qtnetworkng.h"
+
+using namespace qtng;
+
+// 模拟持有 CoroutineGroup 的父对象（类似 NotificationsPagePrivate）
+class CoroutineGroupTest : public QObject
+{
+    Q_OBJECT
+public:
+    CoroutineGroupTest()
+        : operations(new CoroutineGroup())
+    {
+        connect(this, &CoroutineGroupTest::emitTask, this, &CoroutineGroupTest::doTaskAsync, Qt::QueuedConnection);
+    }
+    void doTaskAsync(bool replace)
+    {
+        operations->spawnWithName("task", [] {
+            Coroutine::msleep(500);
+        }, replace);
+    }
+    void startLongTask()
+    {
+        operations->spawnWithName("task", [] {
+            Coroutine::msleep(500);
+        });
+    }
+    QSharedPointer<Coroutine> replaceTask()
+    {
+        return operations->spawnWithName("task", [] {
+            Coroutine::msleep(50);
+        }, true);
+    }
+    void fun()
+    {
+        emit emitTask(true);
+    }
+    ~CoroutineGroupTest()
+    {
+        delete operations;
+    }
+signals:
+    void emitTask(bool replace);
+private:
+    CoroutineGroup *operations;
+};
+
+class TestCoroutineGroupSpawnWithName : public QObject
+{
+    Q_OBJECT
+private slots:
+    void testSpawnWithNameReplace();
+    void testSpawnWithNameReplaceWhileParentDestruct();
+    void testSpawnWithNameReplaceWhileParentDestructFromGroupCoroutine();
+    void testSpawnWithNameReturnsNullWhenGroupDestroyedDuringJoin();
+};
+
+void TestCoroutineGroupSpawnWithName::testSpawnWithNameReplace()
+{
+    CoroutineGroupTest parent;
+    QSharedPointer<Event> finished(new Event());
+
+    parent.doTaskAsync(false);
+    parent.doTaskAsync(true);
+    Coroutine::msleep(500);
+}
+
+void TestCoroutineGroupSpawnWithName::testSpawnWithNameReplaceWhileParentDestruct()
+{
+    // spawnWithName(..., replace=true) 会在 old->join() 处阻塞；
+    // 若 join 期间父对象析构并 delete operations，CoroutineGroup 可能在
+    // spawnWithName 仍在执行栈上时被销毁，导致 use-after-free。
+
+    QList<int> tasks;
+    for (int i = 0; i < 500; i++) {
+        tasks.push_back(i);
+    }
+    CoroutineGroup::each<int>([] (int i) {
+        CoroutineGroupTest *parent = new CoroutineGroupTest();
+        for (int j = 0; j < 10; j++) {
+            parent->doTaskAsync(true);
+        }
+        Coroutine::msleep(500);
+        delete parent;
+    }, tasks);
+}
+
+void TestCoroutineGroupSpawnWithName::testSpawnWithNameReplaceWhileParentDestructFromGroupCoroutine()
+{
+    // 更接近真实用法：由组内协程调用 spawnWithName(..., replace=true)，
+    // 同时在 join 阻塞期间析构持有 CoroutineGroup 的父对象。
+    QList<int> tasks;
+    for (int i = 0; i < 500; i++) {
+        tasks.push_back(i);
+    }
+    CoroutineGroup::each<int>([] (int i) {
+        CoroutineGroupTest *parent = new CoroutineGroupTest();
+        parent->doTaskAsync(false);
+        Coroutine::spawn([parent] {
+            Coroutine::msleep(0);
+            delete parent;
+        });
+        for (int i = 0; i < 100; i++) {
+            parent->fun();
+        }
+    }, tasks);
+}
+
+void TestCoroutineGroupSpawnWithName::testSpawnWithNameReturnsNullWhenGroupDestroyedDuringJoin()
+{
+    bool hitNullReturn = false;
+    QList<int> tasks;
+    for (int i = 0; i < 200; i++) {
+        tasks.push_back(i);
+    }
+    CoroutineGroup::each<int>([&hitNullReturn] (int i) {
+        if (hitNullReturn) {
+            return;
+        }
+        CoroutineGroupTest *parent = new CoroutineGroupTest();
+        parent->startLongTask();
+        Coroutine::msleep(1);
+
+        Coroutine::spawn([parent] {
+            delete parent;
+        });
+
+        QSharedPointer<Coroutine> result = parent->replaceTask();
+        if (result.isNull()) {
+            hitNullReturn = true;
+        }
+    }, tasks);
+    QVERIFY(!hitNullReturn);
+}
+
+int main(int argc, char **argv)
+{
+    qSetMessagePattern("[%{type}][%{time MM-dd hh:mm:ss:zzz}]%{category}: %{message}");
+    QCoreApplication app(argc, argv);
+
+    int result = 0;
+    QScopedPointer<Coroutine> runner(Coroutine::spawn([&result, argc, argv] {
+        TestCoroutineGroupSpawnWithName test;
+        result += QTest::qExec(&test, argc, argv);
+        callInEventLoop([] {
+            if (QCoreApplication::instance()) {
+                QCoreApplication::instance()->quit();
+            }
+        });
+    }));
+    startQtLoop();
+    return result;
+}
+
+#include "test_coroutine_group_spawn_with_name.moc"

--- a/tests/test_https_keepalive.cpp
+++ b/tests/test_https_keepalive.cpp
@@ -1,0 +1,233 @@
+#ifndef QTNG_NO_CRYPTO
+
+#include <atomic>
+#include <QtTest>
+#include "qtnetworkng.h"
+
+using namespace qtng;
+
+namespace {
+
+enum class ServerMode {
+    KeepConnectionOpen,
+    CloseAfterKeepAliveResponseAfterDelay,
+    CloseAfterKeepAliveResponseImmediately,
+};
+
+class KeepAliveTestHandler : public BaseHttpRequestHandler
+{
+public:
+    static ServerMode mode;
+    static std::atomic<int> requestCount;
+
+    void doGET() override
+    {
+        ++requestCount;
+        if (path != QLatin1String("/ping")) {
+            sendError(HttpStatus::NotFound);
+            return;
+        }
+
+        sendResponse(HttpStatus::OK);
+        sendHeader("Content-Type", "text/plain");
+        const QByteArray body("pong");
+        sendHeader("Content-Length", QByteArray::number(body.size()));
+        sendHeader("Connection", "keep-alive");
+        if (!endHeader()) {
+            return;
+        }
+        request->sendall(body);
+        
+        // 模拟 nginx keepalive_timeout：响应头声明 keep-alive，但服务端随后关闭 TLS。
+        if (mode == ServerMode::CloseAfterKeepAliveResponseAfterDelay) {
+            QWeakPointer<SocketLike> requestPtr = request;
+            Coroutine::spawn([requestPtr] {
+                Coroutine::msleep(500);
+                QSharedPointer<SocketLike> request = requestPtr.toStrongRef();
+                if (request.isNull()) {
+                    return;
+                }
+                request->close();
+            });
+        } else if (mode == ServerMode::CloseAfterKeepAliveResponseImmediately) {
+            request->close();
+            closeConnection = Yes;
+        }
+    }
+};
+
+ServerMode KeepAliveTestHandler::mode = ServerMode::KeepConnectionOpen;
+std::atomic<int> KeepAliveTestHandler::requestCount{0};
+
+using KeepAliveHttpsServer = SslServer<KeepAliveTestHandler>;
+
+static QString makePingUrl(quint16 port)
+{
+    return QString::fromLatin1("https://127.0.0.1:%1/ping").arg(port);
+}
+
+}  // namespace
+
+class TestHttpsKeepAlive : public QObject
+{
+    Q_OBJECT
+private slots:
+    void testKeepAliveWorksWhenServerStaysOpen();
+    void testStaleSslKeepAliveConnectionRecoversAfterDelay();
+    void testStaleSslKeepAliveConnectionRecoversImmediately();
+    void testStaleSslKeepAliveDisabledRecovers();
+};
+
+void TestHttpsKeepAlive::testKeepAliveWorksWhenServerStaysOpen()
+{
+    KeepAliveTestHandler::mode = ServerMode::KeepConnectionOpen;
+    KeepAliveTestHandler::requestCount = 0;
+
+    KeepAliveHttpsServer server(HostAddress::LocalHost, 0);
+    QVERIFY(server.start());
+    QVERIFY(server.started()->tryWait(2000));
+    const quint16 port = server.serverPort();
+    QVERIFY(port != 0);
+
+    HttpSession session;
+    session.setKeepAlive(true);
+    session.sslConfiguration().setPeerVerifyMode(Ssl::VerifyNone);
+    const QString url = makePingUrl(port);
+
+    HttpResponse first = session.get(url);
+    QVERIFY2(first.isOk(), qPrintable(first.error() ? first.error()->what() : QString()));
+    QCOMPARE(first.body(), QByteArray("pong"));
+
+    HttpResponse second = session.get(url);
+    QVERIFY2(second.isOk(), qPrintable(second.error() ? second.error()->what() : QString()));
+    QCOMPARE(second.body(), QByteArray("pong"));
+    QCOMPARE(KeepAliveTestHandler::requestCount.load(), 2);
+
+    server.stop();
+    server.wait();
+}
+
+void TestHttpsKeepAlive::testStaleSslKeepAliveConnectionRecoversAfterDelay()
+{
+    KeepAliveTestHandler::mode = ServerMode::CloseAfterKeepAliveResponseAfterDelay;
+    KeepAliveTestHandler::requestCount = 0;
+
+    KeepAliveHttpsServer server(HostAddress::LocalHost, 0);
+    QVERIFY(server.start());
+    QVERIFY(server.started()->tryWait(2000));
+    const quint16 port = server.serverPort();
+    QVERIFY(port != 0);
+
+    HttpSession session;
+    session.setKeepAlive(true);
+    session.setDebugLevel(1);
+    session.sslConfiguration().setPeerVerifyMode(Ssl::VerifyNone);
+    const QString url = makePingUrl(port);
+
+    HttpResponse first = session.get(url);
+    QVERIFY2(first.isOk(), qPrintable(first.error() ? first.error()->what() : QString()));
+    QCOMPARE(first.body(), QByteArray("pong"));
+    QCOMPARE(first.header(KnownHeader::ConnectionHeader).toLower(), QByteArray("keep-alive"));
+    QCOMPARE(KeepAliveTestHandler::requestCount.load(), 1);
+
+    Coroutine::msleep(1000);
+
+    // 服务端已关闭 TLS，连接池应丢弃 stale 连接并新建连接。
+    HttpResponse second = session.get(url);
+    QVERIFY2(second.isOk(), qPrintable(second.error() ? second.error()->what() : QString()));
+    QCOMPARE(second.body(), QByteArray("pong"));
+    QCOMPARE(KeepAliveTestHandler::requestCount.load(), 2);
+
+    server.stop();
+    server.wait();
+}
+
+void TestHttpsKeepAlive::testStaleSslKeepAliveConnectionRecoversImmediately()
+{
+#if 0
+    // TODO: should we do retry in HttpSession::send or SSL_peek and check close
+#else
+    KeepAliveTestHandler::mode = ServerMode::CloseAfterKeepAliveResponseImmediately;
+    KeepAliveTestHandler::requestCount = 0;
+
+    KeepAliveHttpsServer server(HostAddress::LocalHost, 0);
+    QVERIFY(server.start());
+    QVERIFY(server.started()->tryWait(2000));
+    const quint16 port = server.serverPort();
+    QVERIFY(port != 0);
+
+    HttpSession session;
+    session.setKeepAlive(true);
+    session.setDebugLevel(1);
+    session.sslConfiguration().setPeerVerifyMode(Ssl::VerifyNone);
+    const QString url = makePingUrl(port);
+
+    HttpResponse first = session.get(url);
+    QVERIFY2(first.isOk(), qPrintable(first.error() ? first.error()->what() : QString()));
+    QCOMPARE(first.body(), QByteArray("pong"));
+    QCOMPARE(first.header(KnownHeader::ConnectionHeader).toLower(), QByteArray("keep-alive"));
+    QCOMPARE(KeepAliveTestHandler::requestCount.load(), 1);
+
+    // 服务端已关闭 TLS，连接池应丢弃 stale 连接并新建连接。
+    HttpResponse second = session.get(url);
+    QVERIFY2(second.isOk(), qPrintable(second.error() ? second.error()->what() : QString()));
+    QCOMPARE(second.body(), QByteArray("pong"));
+    QCOMPARE(KeepAliveTestHandler::requestCount.load(), 2);
+
+    server.stop();
+    server.wait();
+#endif
+}
+
+
+void TestHttpsKeepAlive::testStaleSslKeepAliveDisabledRecovers()
+{
+    KeepAliveTestHandler::mode = ServerMode::CloseAfterKeepAliveResponseImmediately;
+    KeepAliveTestHandler::requestCount = 0;
+
+    KeepAliveHttpsServer server(HostAddress::LocalHost, 0);
+    QVERIFY(server.start());
+    QVERIFY(server.started()->tryWait(2000));
+    const quint16 port = server.serverPort();
+    QVERIFY(port != 0);
+
+    HttpSession session;
+    session.setKeepAlive(false);
+    session.sslConfiguration().setPeerVerifyMode(Ssl::VerifyNone);
+    const QString url = makePingUrl(port);
+
+    HttpResponse first = session.get(url);
+    QVERIFY2(first.isOk(), qPrintable(first.error() ? first.error()->what() : QString()));
+    QCOMPARE(first.body(), QByteArray("pong"));
+    QCOMPARE(KeepAliveTestHandler::requestCount.load(), 1);
+
+    HttpResponse second = session.get(url);
+    QVERIFY2(second.isOk(), qPrintable(second.error() ? second.error()->what() : QString()));
+    QCOMPARE(second.body(), QByteArray("pong"));
+    QCOMPARE(KeepAliveTestHandler::requestCount.load(), 2);
+
+    server.stop();
+    server.wait();
+}
+
+int main(int argc, char **argv)
+{
+    QCoreApplication app(argc, argv);
+
+    int result = 0;
+    QScopedPointer<Coroutine> runner(Coroutine::spawn([&result, argc, argv] {
+        TestHttpsKeepAlive test;
+        result += QTest::qExec(&test, argc, argv);
+        callInEventLoop([] {
+            if (QCoreApplication::instance()) {
+                QCoreApplication::instance()->quit();
+            }
+        });
+    }));
+    startQtLoop();
+    return result;
+}
+
+#include "test_https_keepalive.moc"
+
+#endif  // QTNG_NO_CRYPTO


### PR DESCRIPTION
Joining from a Qt slot nested QEventLoop::exec() without bound and could use-after-free the CoroutineGroup if the parent was destroyed during join. Wait for the old coroutine inside the new one instead.