### PR TITLE
The listening socket has no peer. SO_KEEPALIVE / TCP_KEEPALIVE (espec…

### DIFF
--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -30,8 +30,6 @@ SocketPrivate::SocketPrivate(HostAddress::NetworkLayerProtocol protocol, Socket:
         setOption(Socket::BroadcastSocketOption, 1);
         setOption(Socket::ReceivePacketInformation, 1);
         setOption(Socket::ReceiveHopLimit, 1);
-    } else if (type == Socket::TcpSocket) {
-        setTcpKeepalive(true, 10, 2);
     }
 }
 

--- a/src/socket_unix.cpp
+++ b/src/socket_unix.cpp
@@ -351,6 +351,7 @@ bool SocketPrivate::connect(const HostAddress &address, quint16 port)
         } while (result < 0 && errno == EINTR);
         if (result >= 0) {
             state = Socket::ConnectedState;
+            setTcpKeepalive(true, 10, 2);
             fetchConnectionParameters();
             return true;
         }
@@ -358,6 +359,7 @@ bool SocketPrivate::connect(const HostAddress &address, quint16 port)
         switch (t) {
         case EISCONN:
             state = Socket::ConnectedState;
+            setTcpKeepalive(true, 10, 2);
             fetchConnectionParameters();
             return true;
         case EINPROGRESS:
@@ -468,6 +470,8 @@ bool SocketPrivate::listen(int backlog)
         }
         return false;
     }
+    // Defense: clear keepalive even if a caller enabled it before listen().
+    setTcpKeepalive(false, 0, 0);
     state = Socket::ListeningState;
     fetchConnectionParameters();
     return true;
@@ -1021,29 +1025,41 @@ QVariant SocketPrivate::option(Socket::SocketOption option) const
 
 bool SocketPrivate::setTcpKeepalive(bool keepalve, int keepaliveTimeoutSesc, int keepaliveIntervalSesc)
 {
+    // BSD/Darwin defaults: net.inet.tcp.keepidle=7200000ms -> 7200s; keepintvl=75s.
+    // When disabling keepalive, restore idle/interval so a later SO_KEEPALIVE-only
+    // enable uses the 2h system default instead of our leftover 10s.
+    static const int kDefaultKeepaliveIdleSecs = 7200;
+    static const int kDefaultKeepaliveIntervalSecs = 75;
+
     int optval = keepalve ? 1 : 0;
     if (!setOption(Socket::KeepAliveOption, optval)) {
         qtng_debug << "failed to set SO_KEEPALIVE on fd" << fd << "errno:" << errno;
         return false;
     }
+
+    const int idleSecs = keepalve ? keepaliveTimeoutSesc : kDefaultKeepaliveIdleSecs;
+    const int intervalSecs = keepalve ? keepaliveIntervalSesc : kDefaultKeepaliveIntervalSecs;
+
 #ifdef TCP_KEEPIDLE
-    optval = keepaliveTimeoutSesc;
+    optval = idleSecs;
     if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, (void *) &optval, sizeof(optval)) < 0) {
         qtng_debug << "failed to set TCP_KEEPIDLE on fd" << fd << "errno:" << errno;
     }
 #elif defined(TCP_KEEPALIVE)
-    /* Mac OS X style */
-    optval = keepaliveTimeoutSesc;
+    /* macOS: TCP_KEEPALIVE is the counterpart of Linux TCP_KEEPIDLE (seconds). */
+    optval = idleSecs;
     if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPALIVE, (void *) &optval, sizeof(optval)) < 0) {
         qtng_debug << "failed to set TCP_KEEPALIVE on fd" << fd << "errno:" << errno;
     }
 #endif
 
 #ifdef TCP_KEEPINTVL
-    optval = keepaliveIntervalSesc;
+    optval = intervalSecs;
     if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, (void *) &optval, sizeof(optval)) < 0) {
         qtng_debug << "failed to set TCP_KEEPINTVL on fd" << fd << "errno:" << errno;
     }
+#else
+    Q_UNUSED(intervalSecs);
 #endif
     return true;
 }

--- a/src/socket_win.cpp
+++ b/src/socket_win.cpp
@@ -553,6 +553,7 @@ static bool setErrorFromWASError(SocketPrivate *d, int err)
         d->setError(Socket::UnknownSocketError, SocketPrivate::UnknownSocketErrorString);
     case WSAEISCONN:
         d->state = Socket::ConnectedState;
+        d->setTcpKeepalive(true, 10, 2);
         d->fetchConnectionParameters();
         return true;
     case WSAEADDRINUSE:
@@ -666,6 +667,7 @@ bool SocketPrivate::connect(const HostAddress &address, quint16 port)
             }
         } else {
             state = Socket::ConnectedState;
+            setTcpKeepalive(true, 10, 2);
             fetchConnectionParameters();
             return true;
         }
@@ -736,6 +738,8 @@ bool SocketPrivate::listen(int backlog)
         qDebug("SocketPrivate::listen(%i) == true", backlog);
     #endif
 
+    // Defense: clear keepalive even if a caller enabled it before listen().
+    setTcpKeepalive(false, 0, 0);
     state = Socket::ListeningState;
     fetchConnectionParameters();
     return true;
@@ -1244,15 +1248,22 @@ bool SocketPrivate::setTcpKeepalive(bool keepalve, int keepaliveTimeoutSesc, int
         return false;
     }
 #if defined(SIO_KEEPALIVE_VALS)
+    // Windows default keepalive idle is ~2h; restore it when disabling so a later
+    // SO_KEEPALIVE-only enable does not keep our leftover 10s.
+    static const int kDefaultKeepaliveIdleSecs = 7200;
+    static const int kDefaultKeepaliveIntervalSecs = 1;
     struct tcp_keepalive vals;
     DWORD dummy;
-    vals.onoff = 1;
-    vals.keepalivetime = 1000 * keepaliveTimeoutSesc;
-    vals.keepaliveinterval = 1000 * keepaliveIntervalSesc;
+    vals.onoff = keepalve ? 1 : 0;
+    vals.keepalivetime = 1000 * (keepalve ? keepaliveTimeoutSesc : kDefaultKeepaliveIdleSecs);
+    vals.keepaliveinterval = 1000 * (keepalve ? keepaliveIntervalSesc : kDefaultKeepaliveIntervalSecs);
     if (WSAIoctl(fd, SIO_KEEPALIVE_VALS, (LPVOID)&vals, sizeof(vals), NULL, 0, &dummy, NULL, NULL) != 0) {
         qtng_debug << "failed to set SIO_KEEPALIVE_VALS on fd" << fd << "errno:" << WSAGetLastError();
         return false;
     }
+#else
+    Q_UNUSED(keepaliveTimeoutSesc);
+    Q_UNUSED(keepaliveIntervalSesc);
 #endif
     return true;
 }


### PR DESCRIPTION
…ially on macOS), which are enabled by default at construction time, may transition the TCP PCB to CLOSED after approximately 10 seconds of idleness, while the user-space state remains in ListeningState.